### PR TITLE
Update `s57_msgs` package.xml

### DIFF
--- a/s57_msgs/package.xml
+++ b/s57_msgs/package.xml
@@ -11,6 +11,7 @@
     
     <license>BSD</license>
 
+    <buildtool_depend>ament_cmake</buildtool_depend>
     <buildtool_depend>rosidl_default_generators</buildtool_depend>
     <exec_depend>rosidl_default_runtime</exec_depend>
     <depend>geographic_msgs</depend>
@@ -18,6 +19,7 @@
     <member_of_group>rosidl_interface_packages</member_of_group>
 
     <export>
+        <build_type>ament_cmake</build_type>
     </export>
     
 </package>


### PR DESCRIPTION
Including `<build_type>ament_cmake</build_type>` so the message definitions get exported correctly