### PR TITLE
Demote dataset count log message from INFO to DEBUG

### DIFF
--- a/s57_layer/src/s57_layer.cpp
+++ b/s57_layer/src/s57_layer.cpp
@@ -480,7 +480,7 @@ void S57Layer::getDatasetsCallback(GetDatasetsClient::SharedFuture future)
   }
   else
   {
-    RCLCPP_INFO_STREAM(logger_, "Received " << result->datasets.size() << " datasets from service");
+    RCLCPP_DEBUG_STREAM(logger_, "Received " << result->datasets.size() << " datasets from service");
   }
 
   current_charts_ = result->datasets;


### PR DESCRIPTION
## Summary

Uncommitted local change from field work (Oct 2025) found during workspace migration from the old `project11/jazzy` layout to `ros2_agent_workspace`.

**Change:** Single line in `s57_layer/src/s57_layer.cpp` — changes `RCLCPP_INFO_STREAM` to `RCLCPP_DEBUG_STREAM` for the "Received N datasets from service" message, reducing log noise during normal operation.

## Investigation needed before merging

- This branch is based on `855b043`, but upstream `jazzy` has since had 5 new commits (docs, package.xml update, uncrustify fix). A rebase is needed.
- The rebase should be clean — upstream changes don't touch this line.
- Trivial change, but confirm the log message isn't useful at INFO level for diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)