### PR TITLE
chore: add ROS 2 build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# ROS 2 / colcon build artifacts
+build/
+install/
+log/
+CMakeFiles/
+__pycache__/
+
+# ENC chart data (downloaded at runtime)
 s57_layer/data/ENC_ROOT
 s57_grids/data/ENC_ROOT


### PR DESCRIPTION
## Summary
- Add `build/`, `install/`, `log/`, `CMakeFiles/`, and `__pycache__/` to `.gitignore`
- Organize existing entries with section comments

Closes #9

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
