### PR TITLE
feat(s57_layer): tide offset correction via chart datum transform

### DIFF
--- a/s57_layer/CMakeLists.txt
+++ b/s57_layer/CMakeLists.txt
@@ -69,6 +69,18 @@ if(BUILD_TESTING)
     tf2_ros::tf2_ros
   )
 
+  ament_add_gtest(test_tide_offset test/test_tide_offset.cpp)
+  target_include_directories(test_tide_offset PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_tide_offset
+    ${PROJECT_NAME}
+    nav2_costmap_2d::nav2_costmap_2d_core
+    nav2_util::nav2_util_core
+    rclcpp::rclcpp
+    tf2_ros::tf2_ros
+  )
+
   ament_add_gtest(test_plugin_loading test/test_plugin_loading.cpp)
   target_link_libraries(test_plugin_loading
     nav2_costmap_2d::nav2_costmap_2d_core

--- a/s57_layer/src/s57_layer.cpp
+++ b/s57_layer/src/s57_layer.cpp
@@ -1,5 +1,7 @@
 #include "s57_layer.h"
 
+#include <cmath>
+
 #include "geodesy/ecef.h"
 #include "geodesy/wgs84.h"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -133,7 +135,12 @@ void S57Layer::updateBounds(double, double, double, double* min_x, double* min_y
         tide_offset_ = new_offset;
         RCLCPP_INFO_STREAM(logger_, "Tide offset updated: " << tide_offset_ << " m (water above chart datum)");
         for(auto& t: tiles_)
+        {
           t.second.complete = false;
+          t.second.chart_count = 0;
+          t.second.needs_update = true;
+        }
+        current_ = false;
       }
     }
     catch(const tf2::TransformException& e)

--- a/s57_layer/src/s57_layer.cpp
+++ b/s57_layer/src/s57_layer.cpp
@@ -138,6 +138,7 @@ void S57Layer::updateBounds(double, double, double, double* min_x, double* min_y
         {
           t.second.complete = false;
           t.second.chart_count = 0;
+          t.second.costmap = nullptr;
           t.second.needs_update = true;
         }
         current_ = false;

--- a/s57_layer/src/s57_layer.cpp
+++ b/s57_layer/src/s57_layer.cpp
@@ -55,6 +55,11 @@ void S57Layer::onInitialize()
   declareParameter("allow_uncharted", rclcpp::ParameterValue(allow_uncharted_));
   node->get_parameter(name_+".allow_uncharted", allow_uncharted_);
 
+  declareParameter("chart_datum_frame", rclcpp::ParameterValue(chart_datum_frame_));
+  node->get_parameter(name_+".chart_datum_frame", chart_datum_frame_);
+  if(!chart_datum_frame_.empty())
+    RCLCPP_INFO_STREAM(logger_, "Tide correction enabled: chart_datum_frame = " << chart_datum_frame_);
+
   declareParameter("s57_grids_namespace", rclcpp::ParameterValue(s57_grids_namespace_));
   node->get_parameter(name_+".s57_grids_namespace", s57_grids_namespace_);
 
@@ -116,6 +121,27 @@ void S57Layer::updateBounds(double, double, double, double* min_x, double* min_y
 {
   if (!enabled_)
     return;
+
+  if(!chart_datum_frame_.empty())
+  {
+    try
+    {
+      auto transform = tf_->lookupTransform(global_frame_id_, chart_datum_frame_, tf2::TimePointZero);
+      double new_offset = -transform.transform.translation.z;
+      if(std::abs(new_offset - tide_offset_) > 0.01)
+      {
+        tide_offset_ = new_offset;
+        RCLCPP_INFO_STREAM(logger_, "Tide offset updated: " << tide_offset_ << " m (water above chart datum)");
+        for(auto& t: tiles_)
+          t.second.complete = false;
+      }
+    }
+    catch(const tf2::TransformException& e)
+    {
+      RCLCPP_WARN_THROTTLE(logger_, *clock_, 10000, "Cannot look up tide offset (%s → %s): %s",
+        chart_datum_frame_.c_str(), global_frame_id_.c_str(), e.what());
+    }
+  }
 
   auto start_time = clock_->now();
 
@@ -421,7 +447,7 @@ unsigned char S57Layer::get_cost_from_grid(grid_map::GridMap &grid, const grid_m
   auto elevation = grid.at("elevation", index);
   if(!std::isnan(elevation))
   {
-    auto depth = -elevation;
+    auto depth = -elevation + tide_offset_;
     if (depth < minimum_depth_)
       return nav2_costmap_2d::LETHAL_OBSTACLE;
     unsigned char cost = nav2_costmap_2d::FREE_SPACE;

--- a/s57_layer/src/s57_layer.h
+++ b/s57_layer/src/s57_layer.h
@@ -99,6 +99,12 @@ private:
   // When false, uncharted areas are marked NO_INFORMATION to block planning.
   bool allow_uncharted_ = true;
 
+  // Optional chart datum frame for tide correction.
+  // When set, the layer looks up chart_datum_frame → global_frame to get
+  // the tide offset (water surface height above chart datum).
+  std::string chart_datum_frame_;
+  double tide_offset_ = 0.0;
+
   typedef std::pair<int, int> TileID;
 
   struct TileInfo

--- a/s57_layer/test/test_tide_offset.cpp
+++ b/s57_layer/test/test_tide_offset.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Roland Arsenault
+// Licensed under BSD license
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/static_transform_broadcaster.h"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+
+#include "s57_layer.h"
+
+class TideOffsetTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+// Helper: publish a static transform for chart_datum -> map with given Z.
+static void publishChartDatumTransform(
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  double z_value)
+{
+  geometry_msgs::msg::TransformStamped t;
+  t.header.stamp = rclcpp::Time(0);
+  t.header.frame_id = "map";
+  t.child_frame_id = "chart_datum";
+  t.transform.translation.x = 0.0;
+  t.transform.translation.y = 0.0;
+  t.transform.translation.z = z_value;
+  t.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(t, "test_authority", true);
+}
+
+// When chart_datum_frame is set and a TF transform changes,
+// the layer should invalidate cached tiles (current_ becomes false).
+TEST_F(TideOffsetTest, TideChangeInvalidatesTiles)
+{
+  auto node = std::make_shared<nav2_util::LifecycleNode>("test_tide_offset");
+
+  // Configure chart_datum_frame parameter
+  node->declare_parameter("chart_layer.chart_datum_frame", std::string("chart_datum"));
+
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  // Publish initial transform: chart datum at Z = -1.0 (1m below global frame)
+  // This means tide_offset_ = -(-1.0) = 1.0 m water above datum
+  publishChartDatumTransform(tf_buffer, -1.0);
+
+  nav2_costmap_2d::LayeredCostmap layered_costmap("map", false, false);
+  layered_costmap.resizeMap(10, 10, 1.0, 0.0, 0.0);
+
+  auto * master = layered_costmap.getCostmap();
+
+  auto layer = std::make_shared<s57_layer::S57Layer>();
+  layer->initialize(&layered_costmap, "chart_layer", tf_buffer.get(), node, nullptr);
+
+  // First cycle: tiles become complete (no charts, uncharted allowed)
+  double minx = 1e30, miny = 1e30, maxx = -1e30, maxy = -1e30;
+  layer->updateBounds(5.0, 5.0, 0.0, &minx, &miny, &maxx, &maxy);
+  layer->updateCosts(*master, 0, 0, 10, 10);
+
+  // Should be current after processing
+  EXPECT_TRUE(layer->isCurrent());
+
+  // Change tide: chart datum at Z = -2.5 (offset changes from 1.0 to 2.5)
+  publishChartDatumTransform(tf_buffer, -2.5);
+
+  // Second cycle: tide change should invalidate tiles
+  minx = 1e30; miny = 1e30; maxx = -1e30; maxy = -1e30;
+  layer->updateBounds(5.0, 5.0, 0.0, &minx, &miny, &maxx, &maxy);
+
+  // current_ should be false after tide invalidation
+  EXPECT_FALSE(layer->isCurrent());
+
+  // After updateCosts, tiles should be regenerated and current again
+  layer->updateCosts(*master, 0, 0, 10, 10);
+  EXPECT_TRUE(layer->isCurrent());
+}
+
+// When chart_datum_frame is empty (default), no TF lookup occurs
+// and tide_offset_ stays at zero.
+TEST_F(TideOffsetTest, NoChartDatumFrameSkipsTideLookup)
+{
+  auto node = std::make_shared<nav2_util::LifecycleNode>("test_no_tide");
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  nav2_costmap_2d::LayeredCostmap layered_costmap("map", false, false);
+  layered_costmap.resizeMap(10, 10, 1.0, 0.0, 0.0);
+
+  auto * master = layered_costmap.getCostmap();
+
+  auto layer = std::make_shared<s57_layer::S57Layer>();
+  layer->initialize(&layered_costmap, "chart_layer", tf_buffer.get(), node, nullptr);
+
+  double minx = 1e30, miny = 1e30, maxx = -1e30, maxy = -1e30;
+  layer->updateBounds(5.0, 5.0, 0.0, &minx, &miny, &maxx, &maxy);
+  layer->updateCosts(*master, 0, 0, 10, 10);
+
+  // Should work fine with no chart_datum_frame — no TF errors
+  EXPECT_TRUE(layer->isCurrent());
+}
+
+// Small tide changes (below threshold) should not invalidate tiles.
+TEST_F(TideOffsetTest, SmallTideChangeIgnored)
+{
+  auto node = std::make_shared<nav2_util::LifecycleNode>("test_small_tide");
+
+  node->declare_parameter("chart_layer.chart_datum_frame", std::string("chart_datum"));
+
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  publishChartDatumTransform(tf_buffer, -1.0);
+
+  nav2_costmap_2d::LayeredCostmap layered_costmap("map", false, false);
+  layered_costmap.resizeMap(10, 10, 1.0, 0.0, 0.0);
+
+  auto * master = layered_costmap.getCostmap();
+
+  auto layer = std::make_shared<s57_layer::S57Layer>();
+  layer->initialize(&layered_costmap, "chart_layer", tf_buffer.get(), node, nullptr);
+
+  double minx = 1e30, miny = 1e30, maxx = -1e30, maxy = -1e30;
+  layer->updateBounds(5.0, 5.0, 0.0, &minx, &miny, &maxx, &maxy);
+  layer->updateCosts(*master, 0, 0, 10, 10);
+  EXPECT_TRUE(layer->isCurrent());
+
+  // Change by only 0.005m — below the 0.01m threshold
+  publishChartDatumTransform(tf_buffer, -1.005);
+
+  minx = 1e30; miny = 1e30; maxx = -1e30; maxy = -1e30;
+  layer->updateBounds(5.0, 5.0, 0.0, &minx, &miny, &maxx, &maxy);
+
+  // Should still be current — change too small
+  EXPECT_TRUE(layer->isCurrent());
+}

--- a/s57_layer/test/test_tide_offset.cpp
+++ b/s57_layer/test/test_tide_offset.cpp
@@ -30,20 +30,24 @@ protected:
   }
 };
 
-// Helper: publish a static transform for chart_datum -> map with given Z.
+// Helper: publish a dynamic transform for chart_datum -> map with given Z.
+// Uses monotonically increasing timestamps since the transform is updated
+// during tests to simulate tide changes.
 static void publishChartDatumTransform(
   std::shared_ptr<tf2_ros::Buffer> tf_buffer,
   double z_value)
 {
+  static int64_t stamp_ns = 1;
+
   geometry_msgs::msg::TransformStamped t;
-  t.header.stamp = rclcpp::Time(0);
+  t.header.stamp = rclcpp::Time(stamp_ns++);
   t.header.frame_id = "map";
   t.child_frame_id = "chart_datum";
   t.transform.translation.x = 0.0;
   t.transform.translation.y = 0.0;
   t.transform.translation.z = z_value;
   t.transform.rotation.w = 1.0;
-  tf_buffer->setTransform(t, "test_authority", true);
+  tf_buffer->setTransform(t, "test_authority", false);
 }
 
 // When chart_datum_frame is set and a TF transform changes,


### PR DESCRIPTION
## Summary

- Adds optional `chart_datum_frame` parameter to the S57 costmap layer
- When set, looks up the `chart_datum → global_frame` (map_tide) transform each update cycle
- Applies the tide offset to chart depths so they represent actual depth below the current water surface
- Invalidates cached tiles when tide changes by more than 1cm
- Backwards compatible: empty `chart_datum_frame` (default) preserves existing behavior

## Configuration

```yaml
chart_layer:
  plugin: "s57_layer::S57Layer"
  chart_datum_frame: bizzy/chart_datum  # enables tide correction
  minimum_depth: 0.0
  maximum_caution_depth: 1.0
```

## How it works

Chart depths reference MLLW (chart datum). When the costmap operates in the `map_tide` frame (water surface), the raw chart depths don't reflect the current tide. This change looks up `chart_datum_frame → global_frame` to get the vertical offset, then adjusts: `actual_depth = chart_depth + tide_offset`.

At high tide (+2m): a 1.5m chart depth becomes 3.5m actual depth (safer).
At low tide (+0.1m): a 1.5m chart depth becomes 1.6m actual depth (tighter margin).

## Test plan

- [ ] Build succeeds (verified locally)
- [ ] Existing behavior unchanged when `chart_datum_frame` is not set
- [ ] Verify in simulation with tide model and chart_datum_node
- [ ] Verify on BizzyBoat with live chart_datum transform

Closes #11

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
