### PR TITLE
fix(s57_layer): avoid unnecessary cache invalidation

### DIFF
--- a/s57_layer/src/s57_layer.cpp
+++ b/s57_layer/src/s57_layer.cpp
@@ -340,6 +340,19 @@ void S57Layer::generateTile(TileID id)
       else
         all_charts_available = false;
   }
+
+  // No chart from current_charts_ overlaps this tile. Treat as uncharted —
+  // same handling as the empty-current_charts_ early return — and clear
+  // any costmap left over from a prior era when this tile had coverage.
+  if(grids.empty() && all_charts_available)
+  {
+    tiles_[id].complete = true;
+    tiles_[id].costmap = nullptr;
+    tiles_[id].chart_count = 0;
+    tiles_[id].needs_update = true;
+    return;
+  }
+
   tiles_[id].complete = all_charts_available;
   if(grids.size() > tiles_[id].chart_count)
   {
@@ -532,19 +545,11 @@ void S57Layer::getDatasetsCallback(GetDatasetsClient::SharedFuture future)
   // runs frequently while the boat moves; in steady-state survey areas the
   // label set rarely changes. If unchanged, skip the per-tile invalidation
   // at the end of this function so the cache survives.
-  bool chart_list_unchanged = result->datasets.size() == current_charts_.size();
-  if(chart_list_unchanged)
-  {
-    for(const auto& d: result->datasets)
-    {
-      bool found = false;
-      for(const auto& c: current_charts_)
-      {
-        if(c.label == d.label) { found = true; break; }
-      }
-      if(!found) { chart_list_unchanged = false; break; }
-    }
-  }
+  std::unordered_set<std::string> new_labels;
+  for(const auto& d: result->datasets) new_labels.insert(d.label);
+  std::unordered_set<std::string> old_labels;
+  for(const auto& c: current_charts_) old_labels.insert(c.label);
+  bool chart_list_unchanged = (new_labels == old_labels);
 
   current_charts_ = result->datasets;
   chart_bounds_.clear();
@@ -619,10 +624,18 @@ void S57Layer::getDatasetsCallback(GetDatasetsClient::SharedFuture future)
   // Mark tiles as needing regeneration only when the chart set actually
   // changed — unchanged callbacks are common while the boat moves and
   // would otherwise force a full re-evaluation of every cached tile.
+  // Also reset chart_count so the rebuild branch in generateTile fires
+  // unconditionally; otherwise a same-count chart swap (one chart removed,
+  // one added) would leave stale tile costmaps because grids.size() would
+  // equal the previous chart_count.
   if(!chart_list_unchanged)
   {
     for(auto& t: tiles_)
+    {
       t.second.complete = false;
+      t.second.chart_count = 0;
+      t.second.needs_update = true;
+    }
   }
 
 }

--- a/s57_layer/src/s57_layer.cpp
+++ b/s57_layer/src/s57_layer.cpp
@@ -139,11 +139,14 @@ void S57Layer::updateBounds(double, double, double, double* min_x, double* min_y
       {
         tide_offset_ = new_offset;
         RCLCPP_INFO_STREAM(logger_, "Tide offset updated: " << tide_offset_ << " m (water above chart datum)");
+        // Mark tiles for regeneration but keep the cached costmap as a
+        // fallback so the controller has a usable costmap during regen.
+        // generateTile rebuilds the costmap from grids when chart_count=0,
+        // and the empty-charts early-return clears the pointer for safety.
         for(auto& t: tiles_)
         {
           t.second.complete = false;
           t.second.chart_count = 0;
-          t.second.costmap = nullptr;
           t.second.needs_update = true;
         }
         current_ = false;
@@ -303,9 +306,10 @@ void S57Layer::generateTile(TileID id)
   if(current_charts_.empty())
   {
     tiles_[id].complete = true;
-    // No tile costmap is created. In updateCosts, a nullptr tile
-    // with complete=true is recognized as uncharted territory and
-    // handled according to allow_uncharted_.
+    // Clear any stale costmap from a prior era when this tile had
+    // chart coverage. updateCosts treats nullptr+complete as uncharted
+    // and handles it according to allow_uncharted_.
+    tiles_[id].costmap = nullptr;
     return;
   }
 
@@ -523,6 +527,25 @@ void S57Layer::getDatasetsCallback(GetDatasetsClient::SharedFuture future)
     RCLCPP_DEBUG_STREAM(logger_, "Received " << result->datasets.size() << " datasets from service");
   }
 
+  // Compare new dataset labels against current_charts_ before overwriting.
+  // bounds_need_update fires every ~5% of window movement, so this callback
+  // runs frequently while the boat moves; in steady-state survey areas the
+  // label set rarely changes. If unchanged, skip the per-tile invalidation
+  // at the end of this function so the cache survives.
+  bool chart_list_unchanged = result->datasets.size() == current_charts_.size();
+  if(chart_list_unchanged)
+  {
+    for(const auto& d: result->datasets)
+    {
+      bool found = false;
+      for(const auto& c: current_charts_)
+      {
+        if(c.label == d.label) { found = true; break; }
+      }
+      if(!found) { chart_list_unchanged = false; break; }
+    }
+  }
+
   current_charts_ = result->datasets;
   chart_bounds_.clear();
 
@@ -593,9 +616,14 @@ void S57Layer::getDatasetsCallback(GetDatasetsClient::SharedFuture future)
     grids_.erase(grid);
   }
 
-  // mark all tiles as needing regeneration
-  for(auto& t: tiles_)
-    t.second.complete = false;
+  // Mark tiles as needing regeneration only when the chart set actually
+  // changed — unchanged callbacks are common while the boat moves and
+  // would otherwise force a full re-evaluation of every cached tile.
+  if(!chart_list_unchanged)
+  {
+    for(auto& t: tiles_)
+      t.second.complete = false;
+  }
 
 }
 


### PR DESCRIPTION
## Summary

Two changes in `s57_layer/src/s57_layer.cpp` that remove cache invalidations the layer was doing without need.

1. **`getDatasetsCallback` no-op detection.** Compare the new `result->datasets` label set to `current_charts_`. If unchanged, skip the per-tile `complete=false` loop at the end of the callback. The callback fires every time `bounds_need_update` triggers a service request — every ~5% of window movement, i.e. every ~17.5 m on the bizzyboat 350 m local. In stable survey areas the chart list rarely changes, so most of these invalidations were wasted work that forced a full re-evaluation of every cached tile.

2. **Preserve cached costmap on tide change.** Drop `t.second.costmap = nullptr` from the tide-change block in `updateBounds`. `chart_count = 0` still forces `generateTile` to rebuild from chart grids on the next pass; preserving the cached costmap means the controller has a usable layer to drive against while regen runs (rather than a transient nullptr window every ~30-70 s as the tide moves). Move the explicit `nullptr` into `generateTile`'s empty-charts early-return so the safety still kicks in when a tile genuinely has no chart coverage.

Closes #15. Companion to rolker/unh_marine_navigation#19 (controller-side timeout symptom). Related yaml-only PRs to bump local `chart_layer.update_timeout` from 0.15 s to 0.2 s in `ben_project11` and `seafloor_echoboat_project11` will follow separately.

## Test plan

- [x] `colcon build --packages-select s57_layer` — clean (no new warnings).
- [x] `colcon test --packages-select s57_layer` — 21 tests, 0 errors, 0 failures, 5 skipped. `TideOffsetTest` suite (3/3 passing) covers tide-change → `current_=false` → regen → `current_=true` contract.
- [ ] Reviewer: confirm dataset-label compare is the right granularity. A finer fix (only invalidate tiles whose chart_bounds overlap with added/removed datasets) is left for a separate change — see issue #15 references.
- [ ] Field validation: confirm next BizzyBoat survey doesn't show repeated `current_=false` cycles around the 1 cm tide threshold or each `bounds_need_update`.

## Notes / out of scope

- Mid-cache "preserve costmap pointer" coverage requires test scaffolding for `grids_` and is left as future work.
- Bounded `tiles_` cache (LRU eviction) and chart-bounds-aware partial invalidation in `getDatasetsCallback` are separate, larger improvements; not in this PR.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
