### PR TITLE
docs: alternative ENC→costmap architecture (clean-room)

### DIFF
--- a/docs/design/alternative_chart_scale_planner.md
+++ b/docs/design/alternative_chart_scale_planner.md
@@ -1,0 +1,139 @@
+# Alternative: Chart-Scale Collection Planner — Starting Point
+
+A second alternative design for ENC-driven path planning, captured here
+as a starting point for a later discussion. **This is not a worked-out
+architecture.** It is the user's idea recorded faithfully, ready to be
+picked up and developed.
+
+The intent is to have it on file alongside
+[`alternative_costmap_architecture.md`](alternative_costmap_architecture.md)
+and [`prior_art_reed_2018.md`](prior_art_reed_2018.md) so the eventual
+comparison exercise has three meaningfully distinct designs to weigh
+against each other (this one, the clean-room costmap design, and Reed's
+work).
+
+## The mental model
+
+Plan the way a human mariner plans a voyage between two harbors —
+e.g., Portsmouth, NH to Boston, MA:
+
+1. Pull the largest-scale (most detailed) chart for the **start**
+   (Portsmouth Harbor).
+2. Notice the start chart doesn't reach the destination.
+3. Find a chart at a coarser scale that **covers both** Portsmouth
+   and Boston. Plan most of the voyage on that.
+4. Pull the largest-scale chart for the **destination** (Boston
+   Harbor). Plan the close-quarters approach there.
+5. The composite plan: large-scale departure → coarse-scale transit
+   → large-scale arrival.
+
+This is how navigators actually do it. The collection of charts each
+person uses isn't a single data structure at one resolution — it's a
+working set assembled per-voyage, with scale chosen to match the
+operational phase.
+
+## Algorithm sketch (chart collection assembly)
+
+```
+1. For start point and end point, find the largest-scale chart
+   containing each.
+2. Iteratively add the next largest scale to the collection from
+   each end (working outward in scale).
+3. Continue until a chart is found at a coarse-enough scale that
+   contains BOTH start and end.
+4. If no single chart spans both, find the smallest-scale charts
+   that can be joined together to cover the gap between the
+   two end-collections.
+```
+
+The output is a *collection* of charts at varying scales, not a
+single map at one scale. Together they cover the full voyage with
+appropriate resolution everywhere along it: fine near departure
+and arrival, coarse in the middle.
+
+## Planner integration
+
+With the chart collection assembled:
+
+- The planner starts on the largest-scale start chart.
+- When the plan would drive off that chart, the planner jumps to the
+  next chart up in the collection.
+- Continues across charts in scale order until reaching the
+  largest-scale destination chart.
+
+Two ways to feed cost into the planner:
+
+### Per-chart rasterization
+
+Each chart is converted into a costmap at a resolution appropriate
+for that chart's scale. This implies the planner expects a
+**fixed-resolution underlying grid** but the resolution is per-chart,
+not global.
+
+To fit nav2, check whether the cost calculation step can be supplied
+as a plugin — if so, each chart in the collection contributes its
+own costmap and the planner navigates across the collection.
+
+### Vector-direct (skip rasterization)
+
+If the planner can call out to a cost function rather than reading a
+grid, the chart never needs to be rasterized at all. Vector features
+are queried directly. This avoids:
+
+- Choosing a rasterization resolution for each chart.
+- Loss of feature precision during rasterization.
+- The memory cost of large rasters at fine resolution.
+
+## Operational behavior
+
+The planner runs continuously:
+
+- As the boat progresses, the relevant charts in the collection
+  update (charts behind the boat can be dropped; charts ahead may
+  be added if the route changes).
+- The plan adjusts as conditions change (tide, vessel state, observed
+  hazards).
+
+## Open questions for the next discussion
+
+A non-exhaustive list of things to work out when this gets picked up:
+
+- **How do "scale" and "largest/smallest" map to ENC metadata?** S-57
+  cells carry compilation scale (`CSCL`) and a usage band; the
+  algorithm needs to be precise about which of these drives chart
+  selection.
+- **What does "next largest scale" mean algorithmically?** Is it the
+  next chart in `CSCL` order that contains the current point, or
+  something more nuanced (e.g., the next chart whose footprint
+  extends *toward* the destination)?
+- **Chart boundaries.** Overlap zones, gaps between cells at the same
+  scale, scale mismatches at the boundary — how does the planner
+  handle the seam?
+- **Where does "next chart up" decision happen?** Per-step in the
+  search, per-segment after a partial plan, or globally as a
+  pre-decomposition into legs?
+- **nav2 plugin point.** Is the right plugin point a costmap layer, a
+  global planner, or a custom planner that operates on the chart
+  collection directly? Stock nav2 global planners assume a single
+  costmap; this approach probably wants something bespoke at the
+  planner level.
+- **Vector-direct planning.** Stock nav2 planners read grids; a
+  vector-cost approach would likely require a custom planner. Worth
+  knowing what that costs in development effort vs. what we gain.
+- **What about the "no chart covers this gap" case?** The algorithm
+  has a fallback (smallest-scale charts joined together) — what
+  happens if no joinable set exists? Does that just fail, or is there
+  a different recovery?
+- **Tide and dynamic state across scales.** A single tide value is
+  fine on a harbor-scale chart but not over a 100-km transit chart
+  (covered in the costmap-architecture doc's section 4). How does
+  this interact with the per-chart cost generation?
+
+## What this is *not*
+
+- Not a critique or alternative to the costmap-architecture doc — a
+  parallel design.
+- Not analyzed for feasibility or performance yet.
+- Not committed to as the path forward.
+
+This file gets picked up next time we discuss alternatives.

--- a/docs/design/alternative_costmap_architecture.md
+++ b/docs/design/alternative_costmap_architecture.md
@@ -1,0 +1,749 @@
+# Alternative ENC → Costmap Architecture
+
+A clean-room design for generating nav2-compatible costmaps from S-57 Electronic
+Navigational Chart (ENC) data, produced **without consulting the existing
+implementation in this repo**. This document records the design exercise that
+produced the architecture: not just the conclusions, but the questions asked,
+the options considered, and the reasoning behind each decision.
+
+The intent is comparison. Once this design exists, it can be compared against
+the implementation in `s57_grids` / `s57_layer` / `marine_charts` to surface
+shared assumptions, divergent choices, and places where either design is
+stronger.
+
+Tracked by [#23](https://github.com/rolker/s57_tools/issues/23).
+
+## Reading guide
+
+The document is structured chronologically by the conversation that produced
+it, lightly edited for flow:
+
+1. [Inputs and constraints](#1-inputs-and-constraints) — the framing pass,
+   before any architecture discussion.
+2. [Resolution and tiering](#2-resolution-and-tiering) — what resolution is
+   actually needed, and why nav2's standard global+local pattern fits.
+3. [Four prep questions](#3-four-prep-questions) — design choices that needed
+   to be settled before the architecture made sense.
+4. [The multi-leg mission scenario](#4-the-multi-leg-mission-scenario) — a
+   late-breaking case (regional missions covering hundreds of km) and how it
+   shaped the design.
+5. [Architecture](#5-architecture) — the actual pipeline, layer breakdown,
+   composition rule, modules, and update model.
+6. [v1 scope and deferrals](#6-v1-scope-and-deferrals) — what should ship,
+   and what is explicitly deferred.
+7. [Where confidence is low](#7-where-confidence-is-low) — places where the
+   answer is a best guess rather than a settled decision.
+
+## 1. Inputs and constraints
+
+### Inputs
+
+**Chart data**
+
+- S-57 ENC cells (`.000` base + `.00N` updates), or a pre-converted form
+  (GeoPackage, OGR-readable). Per cell: header metadata (scale, datum,
+  edition), and vector features with geometry (point/line/area) plus IHO-coded
+  attributes.
+- The feature classes that actually drive a marine costmap are a small subset
+  of S-57: `LNDARE`, `COALNE`, `DEPARE`, `DRGARE`, `DEPCNT`, `SOUNDG`,
+  `UWTROC`, `OBSTRN`, `WRECKS`, `RESARE`/`PRCARE`, `BRIDGE`, `CBLSUB`/`PIPSOL`,
+  `FAIRWY`, `TSSLPT`/`TSEZNE`, plus aids (`BOYxxx`, `BCNxxx`, `LIGHTS`) — the
+  latter mainly as keep-clear points, not as obstacles.
+- Multiple cells of differing scale (`CSCL`) usually overlap; the "best"
+  feature at a point is the one from the largest-scale cell that contains it.
+
+**Vehicle / mission state** (these turn raw chart features into costs)
+
+- Static vessel params: draft, beam, length, air-draft, turning radius,
+  safety margin.
+- Dynamic state: current tidal offset relative to chart datum (LAT/MLLW),
+  and the planning horizon (now vs. when the boat would actually be there).
+- Optionally: vessel class / rules profile (commercial vs. small craft —
+  changes how `RESARE` / TSS are treated).
+
+**Map / runtime config**
+
+- Target frame (typically a local ENU/UTM map frame), origin geodetic anchor,
+  grid resolution and extent, update rate.
+- Cost policy: which feature → which cost, inflation radii, hard-vs-soft
+  thresholds, unknown-cell policy.
+
+### Constraints
+
+**Semantic / correctness**
+
+- Depth is *relative*: a `DEPARE` with `DRVAL1 = 2 m` is lethal at 3 m draft
+  and benign at 1 m. Cost must be derived from
+  `(depth − tide) − draft − safety_margin`, not baked in.
+- Feature priority is non-trivial: a `WRECKS` point lies *inside* a `DEPARE`
+  polygon; the wreck must win locally. Rasterization order alone is fragile —
+  an explicit priority/merge rule is needed.
+- Polygons have holes (an island inside a depth area, a depth area inside
+  land reclamation). The rasterizer has to honor them or land becomes
+  navigable.
+- Geographic → planar projection introduces distortion; for a few-km map it's
+  negligible, for a large operating area it isn't.
+
+**Operational**
+
+- ENC cells are large; pre-rasterizing every cell at high resolution is
+  wasteful. The robot only needs the local window, but tide updates
+  invalidate any cached depth-derived costs globally.
+- Updates: tide changes are slow (minutes), vessel params change rarely, the
+  chart itself is effectively static per mission. That asymmetry suggests
+  separating "what's there" (cacheable, vessel-independent) from "what it
+  costs me" (recomputed when tide/draft change).
+- nav2 expects a `nav_msgs/OccupancyGrid` or layered `Costmap2D`. Layered is
+  the natural fit because each S-57 concern (land, depth, point obstacles,
+  regulatory) maps cleanly to one layer with its own update rule.
+- Provenance / debuggability: when a planner refuses to cross a cell, the
+  operator needs to know *which feature* did it. That's a real constraint on
+  the pipeline, not a nice-to-have.
+
+**Edge cases worth naming up front**
+
+- Cell boundaries (no double-cost in overlap zones, no gaps).
+- Unsurveyed areas (`UNSARE`) — neither free nor blocked; "unknown" is a real
+  value, not a failure mode.
+- Soundings (`SOUNDG`) are point depths, often denser than `DEPARE` resolution
+  — do we use them, or trust the polygons?
+- Time-varying features (lights, seasonal buoys) — probably out of scope, but
+  worth deciding explicitly.
+
+### Scope decisions made up front
+
+- **Scope**: just the static-environment costmap layer that nav2's local /
+  global planner consumes. Dynamic AIS / radar tracks are a separate concern.
+- **Tide handling**: the boat publishes a scalar tide-offset estimate at its
+  current location. For short-term planning this is fine; spatially varying
+  tide is deferred.
+
+## 2. Resolution and tiering
+
+The driving constraint on resolution is the UNH pier: piling diameter ~0.3–0.5 m,
+gaps between pilings on the order of 4–8 m, and a BizzyBoat-class hull at ~2 m
+beam wanting maybe 1–2 m of clearance per side.
+
+The rasterization rule of thumb: a point obstacle occupies at minimum 1 cell,
+and once it straddles a cell boundary, 2 cells (so its effective width is
+`r` to `2r`). Then inflation is added on top.
+
+| Resolution | Piling footprint | + 1.5 m inflation each side | Usable in a 6 m gap |
+|------------|------------------|----------------------------|---------------------|
+| 1.0 m      | 1–2 m            | ~5 m total                 | ~1 m — too tight    |
+| 0.5 m      | 0.5–1 m          | ~3.5–4 m total             | ~2 m — workable     |
+| 0.25 m     | 0.25–0.5 m       | ~3.25 m                    | comfortable         |
+
+**Decision**: 0.5 m for the close-quarters layer. 0.25 m would be safer but
+quadruples memory and rasterization cost for a marginal gain on a 2 m hull.
+
+That choice forces the **coverage** question, because 0.5 m everywhere does not
+scale: Portsmouth Harbor + Great Bay (~5 km × 5 km) at 0.5 m is 100 M cells per
+layer, ~100 MB just for one layer.
+
+### Coverage options considered
+
+**(a) Single full-area static map** at one resolution.
+Simple, cacheable, but pays full-area cost at whatever the worst-case
+resolution is. At 0.5 m over a real operating area this hurts; at 2 m the pier
+doesn't work.
+
+**(b) Two-tier: coarse global + fine local window.**
+Global costmap at ~2–4 m covers the operating area for route planning. Local
+costmap at 0.5 m covers a window (e.g., 200 m × 200 m, 160 k cells) sliding
+with the vessel for obstacle-aware control. This matches nav2's existing
+pattern — global and local planners read separate costmaps.
+
+**(c) Single fine-resolution sliding window only.**
+Rules itself out for survey work because the global planner needs a route
+across the whole operating area.
+
+**Decision**: (b). Matches nav2 architecture, keeps memory bounded, same cost
+model in both — just rasterized at different resolutions from the same source.
+
+A consequence flagged early: a single boat-position tide estimate is fine for
+the local window (within a few hundred metres of the boat) but applies that
+same scalar to the far corner of the global costmap. For *route planning* (not
+control) this is acceptable — the route gets re-evaluated as the boat moves
+and tide updates — but the global map's depth layer is "approximate, refreshed
+continuously" rather than "accurate everywhere right now."
+
+## 3. Four prep questions
+
+Before sketching architecture, four questions had to be settled. Each is
+recorded with the options considered, the decision, and the reasoning.
+
+### 3.1 Soundings (`SOUNDG`) versus depth areas (`DEPARE`)
+
+**The semantic asymmetry that drives the question:**
+
+- `DEPARE` is a polygon with `DRVAL1` (shoalest depth in the area) and `DRVAL2`
+  (deepest). A cartographer drew it by tracing depth contours and applying
+  generalization — it's a *judgment* about what the seafloor looks like in
+  that band.
+- `SOUNDG` is a point with a discrete depth from the underlying hydrographic
+  survey. The chart shows a curated subset, not all sampled depths. Compilers
+  deliberately keep shoal soundings visible even when they fall inside a
+  deeper-band polygon, as warnings.
+- A `SOUNDG` of 1.5 m sitting inside a "2–5 m" `DEPARE` is **not a contradiction
+  or a chart error** — it's a flag saying "this area is mostly 2–5 m but
+  there's a shallow spot here, watch out."
+
+You cannot just pick one.
+
+**Options:**
+
+**(a) DEPARE only.** Clean coverage but loses every shoal-spot warning the
+cartographer encoded as a sounding. The boat would happily drive over a 1.5 m
+least-depth point sitting inside a "2–5 m" polygon.
+
+**(b) DEPARE as base, SOUNDG as override-when-shoaler.** Rasterize DEPARE for
+full coverage. For each SOUNDG, look up the cell's current depth — if the
+sounding is shoaler, replace it (and apply a small inflation, since the
+point's actual position has uncertainty). SOUNDG only ever makes things
+shoaler, never deeper.
+
+**(c) Interpolate SOUNDG into a continuous depth raster, drop DEPARE.** This
+is what hydrographic gridding software does (CUBE, IDW, splines). Wrong tool:
+SOUNDG density on an ENC is uneven and *biased* — the cartographer picked
+points for navigational prominence, not statistical sampling. Interpolating
+between two soundings 200 m apart gives a smooth ramp that may have nothing to
+do with the actual bottom (could be a steep bank). And it throws away the
+cartographer's expert generalization.
+
+**Decision: (b).** DEPARE is the authoritative "what does the chart claim
+here" because the cartographer's generalization is signal, not noise. SOUNDG
+is the authoritative "warning point" mechanism.
+
+**Mechanical points that fall out:**
+
+- For DEPARE cost, use `DRVAL1` (shoalest), not the average. We are a
+  navigator, not a statistician.
+- DEPCNT (depth contour) lines are redundant with DEPARE if the data is
+  consistent — the polygon's `DRVAL1` equals the shoaler bounding contour. We
+  can ignore DEPCNT and just trust the polygons.
+- When two SOUNDGs land in the same cell at high resolution, take the shoaler
+  — same rule.
+- The "small inflation" around a SOUNDG matters: positional uncertainty
+  (`QUAPOS`) on a sounding can be metres. A SOUNDG point with no inflation
+  under-represents what it's warning about. Half a cell to one cell feels
+  right at 0.5 m resolution; this should be configurable.
+
+### 3.2 UNSARE (unsurveyed area) handling
+
+**What UNSARE is**: a polygon marking water that hasn't been hydrographically
+surveyed (or not to modern standards). Important distinction: it's still
+**water**, not land. The boat physically can be there — we just don't know
+what's under it.
+
+**Options:**
+
+1. **Lethal (cost 254).** "Assume the worst." Conservative, but claims a
+   certainty we don't have — there's no obstacle there, we just don't know.
+2. **Unknown (cost 255 / `NO_INFORMATION`).** Honest. nav2's default planner
+   behavior treats unknown as non-traversable (`allow_unknown=false`), so
+   practically the boat still won't enter, but the layered costmap preserves
+   the "absence of data" semantic for downstream consumers.
+3. **Free space.** No.
+4. **Per-mission configurable.** Operator chooses 1 or 2 at mission start.
+
+**The wrinkle: this is a survey boat.** The end goal is autonomous surveys —
+UNSARE is exactly the kind of place a survey boat might be tasked to go, to
+fill it in. That changes the framing.
+
+**The clean separation: the costmap reports facts, the planner makes the policy.**
+
+- Costmap layer: UNSARE → 255 (unknown). Always. The truthful representation.
+- Planner config: `allow_unknown` is mission-policy. Operational transit →
+  false (boat refuses to enter). Survey mission targeting an UNSARE polygon →
+  true (boat may enter, with the implicit assumption that downstream sensors
+  will clear ahead).
+
+This keeps the costmap purely descriptive and pushes the risk decision to the
+layer that should own it. It also avoids a category error where the
+*cost mapping* becomes mission config instead of just the planner.
+
+**Decision: option 2**, with `allow_unknown` exposed as planner config rather
+than baked into the costmap.
+
+**Related cells, same rule:**
+
+- Outside any loaded ENC cell: 255. No data is no data.
+- Inside the operating area but no DEPARE / UNSARE / LNDARE covers it: 255.
+  Treat absence of feature as absence of information, not as free water.
+
+**Explicitly not done in v1**: ZOC (Zone of Confidence). S-57 charts encode
+survey quality via `M_QUAL` polygons with `CATZOC` values (A1/A2/B/C/D/U). We
+could go further and use ZOC to *scale our confidence* in DEPARE depths —
+e.g., add a depth uncertainty to `DRVAL1` based on ZOC class. That's a real
+improvement but it's gold-plating for v1. Flagged as a future layer.
+
+### 3.3 Regulatory features
+
+**The taxonomy**: "regulatory" lumps together genuinely different things.
+
+| Feature             | What it actually is                                      | Costmap treatment                       |
+|---------------------|----------------------------------------------------------|----------------------------------------|
+| `RESARE`            | Could be *anything* — depends on `CATREA` / `RESTRN`     | Depends entirely on attributes         |
+| `FAIRWY`            | Designated/dredged channel for big ships                 | Soft — avoid as small craft            |
+| `TSSLPT`/`TSEZNE`   | Traffic separation scheme lanes/zones                    | Soft — stay out, ideally direction-aware |
+| `ACHARE`            | Anchorage area                                           | Soft — boats may be anchored here      |
+| `MARCUL`            | Aquaculture (oyster farms, mussel rafts)                 | Should be near-lethal — physical       |
+| `CTNARE`            | Caution area                                             | Informational, no costmap effect       |
+| `CBLSUB`/`PIPSOL`   | Submarine cables / pipelines                             | Lethal for *anchoring*, irrelevant for surface |
+| `DMPGRD`            | Dumping ground                                           | Usually historical, low cost           |
+| `MIPARE`            | Military practice area                                   | Time-varying; usually soft, sometimes lethal |
+
+**The big trap**: `RESARE` is the most regulatory-looking class and the
+**most attribute-dependent**. The same feature class covers:
+
+- `RESTRN=7` entry prohibited → genuinely lethal (security zones, minefields)
+- `RESTRN=1` anchoring prohibited → completely irrelevant to a
+  surface-navigating costmap
+- `CATREA=2` nature reserve → soft preference
+- `CATREA=12` no-wake area → speed limit, not a costmap concern at all
+- `CATREA=15` environmentally sensitive → soft preference
+
+A v1 that treats `RESARE → lethal` will brick the entire harbor on day one.
+The attributes are not optional — they're load-bearing.
+
+**Scope options:**
+
+**(a) Hard exclusions only.**
+- `RESARE` where `RESTRN ∈ {7, 14}` (entry prohibited / contact prohibited) → lethal.
+- `MARCUL` → lethal (or near-lethal — it's a physical obstruction more than a regulation).
+- Everything else regulatory → ignored.
+
+Defensible v1, very small spec, almost certainly correct as far as it goes.
+
+**(b) Hard exclusions + soft preferences.**
+- All of (a), plus:
+- `RESARE` with environmental / nature attributes → high soft cost (~200).
+- `TSSLPT` / `TSEZNE` → high soft cost. Direction-of-travel ignored for v1.
+- `FAIRWY` → small soft cost (~50) for a small autonomous craft, since we
+  mostly want to *avoid* big-ship lanes when there's an alternative.
+  Optionally zero.
+- `ACHARE` → small soft cost; might have anchored vessels.
+
+More useful, but commits to a cost-policy table that needs maintenance and
+operator review.
+
+**(c) Full regulatory awareness.** TSS direction enforcement, vessel-class
+profiles, time-varying military zones, seasonal rules. Out of scope for v1.
+
+**Decision: (b), structured as a config-driven mapping table.**
+
+**Two architectural commitments fall out:**
+
+1. **Regulatory should be a separate costmap layer (or set of layers) from the
+   depth layer.** They have totally different update properties (depth
+   changes with tide, regulatory effectively never) and different failure
+   modes (a depth bug is a safety issue, a fairway-cost bug is a quality
+   issue). Mixing them couples invariants that shouldn't be coupled.
+2. **No hardcoded class → cost mappings.** Ship a defaults YAML
+   (`RESARE+RESTRN → cost`, `FAIRWY → cost`, etc.) that the operator can
+   review and override. The mapping is policy, not code.
+
+**Subtleties:**
+
+- **RESARE polygons can be huge** (a no-anchoring zone may cover an entire
+  harbor). Even at "soft" cost, painting a large area at cost 200 will distort
+  planning over miles. The cost magnitude needs to scale with the *kind* of
+  restriction, not the polygon size.
+- **MARCUL is misclassified as "regulatory."** Aquaculture infrastructure —
+  buoys, longlines, rafts, oyster cages — is physical and real. It belongs in
+  a "static obstacle" layer with WRECKS and OBSTRN, not regulatory. But it's
+  encoded as an area with regulatory-ish framing in S-57, so it's flagged
+  here.
+- **FAIRWY soft-cost direction is debatable.** Some operators want the boat
+  to *prefer* fairways (predictable bottom, marked, well-charted). Others
+  want it to *avoid* them (commercial traffic). The right answer depends on
+  operating posture; lean avoid for an autonomous small craft, but it's a
+  config knob, not a hardcoded rule.
+
+### 3.4 Operating-area definition
+
+**Options considered:**
+
+**(a) Per-mission config.** Operator sets a bounding box at mission start.
+
+**(b) Union of loaded ENC cells.** Killed by scale: a single Maine coastal
+cell can cover hundreds of square km. At 2 m global resolution that's
+billions of cells.
+
+**(c) Auto-fit to waypoints + margin.** Compute extent from start pose +
+waypoints + return-home + some margin.
+
+**(d) Deployment-level operating area.** Operator defines an area once at
+deployment ("Great Bay", "Portsmouth Harbor near Judd Gregg pier"); all
+subsequent missions for that deployment use it. Persists across missions.
+
+**Decision: (d) primary, (c) as fallback when (d) isn't set.**
+
+The operating area is genuinely a *deployment* concept, not a *mission*
+concept. The boat goes to a location, sits there for a deployment, runs many
+missions. Re-defining the costmap extent before every mission would be
+ceremony with no information content.
+
+(c) is the right fallback for the case where someone fires up the boat
+without setting anything. Just don't make it the primary mechanism, because
+mid-mission replans should not silently resize the costmap.
+
+(a) is what you get when the operator explicitly overrides for a one-off —
+keep the path open, don't make it the default.
+
+**Architectural consequence**: this unifies cleanly with the UNSARE decision
+— **outside the operating area = unknown (255)**, same as outside-loaded-ENC
+and feature-gaps. The operating area is just "where the global costmap exists
+at all." Beyond it, the planner sees out-of-bounds and refuses to plan there,
+which is the safe behavior.
+
+That gives one concept driving two things:
+- Global costmap rasterization extent.
+- Which ENC cells actually need to be loaded and rasterized.
+
+**Memory / resolution interaction:**
+
+| Area                          | At 2 m  | At 4 m | At 8 m |
+|-------------------------------|---------|--------|--------|
+| 2 km × 2 km (small bay)       | 1 M     | tiny   | tiny   |
+| 5 km × 5 km (Great Bay)       | 6 M, ~6 MB  | 1.5 M  | 0.4 M  |
+| 10 km × 10 km (Portsmouth + approaches) | 25 M, ~25 MB | 6 M | 1.5 M |
+| 50 km × 50 km (regional transit) | 625 M — no | 156 M | 39 M |
+
+Global resolution is a config knob with a sane default for the typical
+operating-area size, not a hardcoded constant.
+
+**Edge cases settled:**
+
+- Boat leaves operating area: planner refuses to plan into out-of-bounds.
+  Ops gets a clear failure ("destination outside operating area") rather
+  than weird routing through unknown space.
+- Operating area straddles ENC cell boundaries: feature-gap cells inside the
+  area are 255. Same rule as the rest.
+
+## 4. The multi-leg mission scenario
+
+A scenario surfaced after the four prep questions and re-shaped the operating-area
+discussion: a larger boat departs Portsmouth, NH, transits to a survey area near
+Cape Cod, stops at Provincetown, MA for refuel, returns to survey, then returns
+home to Portsmouth. Total mission scope: ~200 km × 100 km bounding box.
+
+### The size problem
+
+| Resolution | Cells | Memory      |
+|-----------|-------|-------------|
+| 2 m       | 5 G   | impossible  |
+| 4 m       | 1.25 G | impossible |
+| 8 m       | 312 M | very rough  |
+| 16 m      | 78 M  | ~78 MB, feasible |
+| 32 m      | 20 M  | ~20 MB, comfortable |
+
+A single global costmap covering the whole mission is feasible, but only at
+16–32 m. At that resolution coastlines and major shoals resolve fine, but a
+piling cannot. The instinctive reaction is "we need multi-resolution /
+multi-zone." That instinct deserves stress-testing.
+
+### What is the global costmap actually for?
+
+The nav2 global planner's job is *route planning* — find a safe path from
+where the boat is now to where it needs to go, avoiding land and major
+hazards. For a 175 km transit, it has to know about the New Hampshire and
+Massachusetts coastlines and shoals like Stellwagen Bank, but it does not
+need to know about pilings at the Provincetown harbor entrance — the boat
+won't be near them until it arrives.
+
+What about the *survey area*? Does nav2's global planner need fine resolution
+there to plan the survey pattern? **No** — survey patterns (lawnmower lines)
+are generated by a *mission planner*, not by nav2's grid planner. The
+autonomy executes pre-computed lines and uses the local costmap to avoid
+trouble. The global costmap's job is only to route the boat *to* the survey
+area, not to plan the survey itself.
+
+What about the *harbor approach* (Portsmouth pier, Provincetown harbor)? The
+local 0.5 m sliding window is exactly the right tool. It moves with the
+boat. By the time the boat is approaching the pier, the local costmap has
+the pier at 0.5 m. The global costmap's 32 m is fine for "go through the
+harbor entrance roughly here."
+
+### Two architectures considered
+
+**(α) Single global, mission-scoped resolution and extent.**
+- Harbor mission: global at 2 m, 5 km × 5 km.
+- Regional mission with transits: global at 16–32 m, 250 km × 150 km.
+- Local always at 0.5 m, sliding 200 m × 200 m.
+- Stock nav2 global+local pattern. One operating area concept, just larger
+  and coarser when needed.
+- Limitation: no fine-resolution awareness anywhere outside the local window.
+
+**(β) Multi-zone: union of operational areas + transit corridors.**
+- Operational zones (Portsmouth, Cape Cod survey area, Provincetown) at fine
+  global resolution.
+- Transit corridors between them at coarse resolution (or even just
+  route-graph waypoints, not a grid at all).
+- Boat "knows what mode it's in" — operational zone vs. transit — and the
+  active global costmap reflects that.
+- Cost: substantially more architecture. Zone transitions, costmap loading /
+  unloading, potentially custom planner logic. Not stock nav2.
+
+**Decision: (α) for v1.** The role argument convinces: nav2's global
+costmap is for *route planning*, not survey-pattern execution. The gap (β)
+closes is mostly hypothetical for how marine autonomy actually plans.
+
+**(β) becomes necessary if/when:**
+
+- Grid-based planning is wanted over a survey area at sub-metre resolution
+  *simultaneously* with grid-based long-range transit.
+- Missions cover geography too large for any single resolution to span.
+
+Both are genuine future possibilities for the larger boats, but neither is a
+v1 requirement.
+
+**Implementation note**: lazy / tile-based rasterization becomes important
+at 200 km × 100 km. The global costmap should be tiled internally, with
+tiles invalidated and rebuilt as needed — but that's an implementation
+detail under the (α) architecture, not a separate architecture.
+
+## 5. Architecture
+
+### 5.1 Pipeline overview
+
+```
+ENC files
+   │
+   ▼
+[Parse S-57] ──► vector features (geom + attrs) per cell
+   │
+   ▼
+[Spatial index] ──► R-tree keyed on map-frame coords
+   │
+   ▼
+[Layer rasterizers] ──► one grid per logical layer
+   │
+   ▼
+[Composer] ──► final 2D costmap
+   │
+   ▼
+nav2 (Costmap2D / OccupancyGrid)
+```
+
+Single ENC ingest, multi-layer rasterization, max-cost composition. The
+interesting design choices live in the layer breakdown and the update strategy.
+
+### 5.2 Layer breakdown
+
+Five logical layers, organized by **update trigger** rather than by feature
+type — that's the cut that actually matters operationally.
+
+| Layer             | Sources                                                  | Cost behavior        | Update trigger                       |
+|-------------------|----------------------------------------------------------|----------------------|--------------------------------------|
+| **Land**          | `LNDARE`, closed `COALNE`, `SLCONS`                      | Lethal               | Chart load (rare)                    |
+| **Hard regulatory** | `RESARE` with `RESTRN ∈ {entry / contact prohibited}`, `MARCUL`, surface-piercing `OBSTRN` / `UWTROC` / `WRECKS` | Lethal | Chart load |
+| **Soft regulatory** | `RESARE` (env / nature / fish), `FAIRWY`, `TSSLPT` / `TSEZNE`, `ACHARE` | Soft (config-driven) | Chart load + vessel-class change |
+| **Coverage**      | `UNSARE`, area outside any feature polygon, area outside loaded ENC cells | 255 unknown | Chart load |
+| **Depth**         | `DEPARE` (`DRVAL1`) + `SOUNDG` override + tide/draft-conditional `UWTROC` / `WRECKS` / `OBSTRN` | Continuous (depth → cost function) | Chart load + tide + draft |
+
+The cut: 4 of the 5 layers are static after chart load. Only **Depth** needs
+continuous refresh. That asymmetry drives the implementation — static layers
+can be pre-rasterized and held; the depth layer is the only one with
+hot-path complexity.
+
+Each layer is a `nav2_costmap_2d::Layer` plugin. Layered costmaps are
+exactly what nav2's plugin architecture is for; reusing it avoids reinventing
+composition, transforms, and ROS-side plumbing.
+
+### 5.3 Composition rule
+
+Cell-by-cell, applied in this order:
+
+1. Start every cell at 255 (unknown).
+2. Coverage layer keeps unsurveyed / out-of-data cells at 255.
+3. Land, Hard Regulatory, Soft Regulatory, Depth each report a cost (or
+   skip the cell).
+4. **Combination**: any real cost (0–254) overrides 255. Among real costs,
+   **max wins**.
+
+The "max wins" rule is the right default because every layer is a
+hazard-or-preference cost. Notes:
+
+- A SOUNDG override inside a DEPARE polygon is handled *inside* the Depth
+  layer, not by composition — same reasoning as 3.1.
+- Deliberately not using nav2's `addExtra` semantics; max-only is cleaner
+  and the regulatory-vs-physical priorities work out.
+
+### 5.4 The Depth layer in detail
+
+It's the only complex layer.
+
+**Inputs:**
+
+- `DEPARE` polygons with `DRVAL1` (shoalest depth in band).
+- `SOUNDG` points with depth values.
+- Conditional point obstacles (`UWTROC`, `WRECKS`, `OBSTRN`) where the
+  attribute `VALSOU` (or feature flag for "always dangerous") indicates
+  depth-conditional shoaling.
+- Tide offset (scalar).
+- Vessel draft + safety margin.
+
+**Per cell:**
+
+```
+charted_depth   = DEPARE.DRVAL1 at this cell
+                  (or SOUNDG depth if shoaler than DEPARE within search radius)
+effective_depth = charted_depth - tide_offset
+clearance       = effective_depth - draft - safety_margin
+```
+
+Then a **clearance → cost function** maps clearance to 0–254:
+
+- `clearance < 0`              → lethal (254)
+- `0 ≤ clearance < margin_warn` → high cost, gradient
+- `clearance ≥ margin_safe`     → free (0)
+- Linear or smoothstep between thresholds; configurable.
+
+This function is *config*, not code. Different vessels / missions tolerate
+different clearance margins.
+
+For depth-conditional point obstacles: same clearance computation, but
+stamped at the point with a small inflation (1 cell at 0.5 m local; possibly
+larger at coarse global to avoid the point being lost to rasterization).
+
+**Update model**: when tide changes, recompute the entire depth layer. At
+16 m / 80 M cells, this is a few hundred ms — fast enough for tide-update
+rates (minutes). At 0.5 m / 160 k cells (local window), trivially fast.
+
+**Optimization (deferred)**: cache the *clearance* values rather than the
+cost. A tide update then just adds an offset to clearance and re-runs the
+cost function. Faster than re-rasterizing from vectors. v2 work.
+
+### 5.5 Static-layer rasterization
+
+Land, Hard Regulatory, Soft Regulatory, Coverage are computed once when the
+chart loads, into raster form, and held.
+
+For the **global costmap** at 16–32 m / mission-scoped extent: full rasters
+fit easily in memory. Compute and hold them.
+
+For the **local 0.5 m sliding window**: full pre-rasterization at 0.5 m over
+the operating area is impossible. Two options:
+
+- **Tile-based**: pre-rasterize fixed tiles (e.g., 200 m × 200 m at 0.5 m →
+  160 k cells per tile, ~160 KB) on demand. Cache recently-used tiles. Drop
+  tiles far from the boat.
+- **Vector-on-demand**: at each local-costmap update, query the spatial
+  index for features inside the window, rasterize directly into the local
+  grid.
+
+**Decision**: start with vector-on-demand for the local window — the window
+is tiny (~160 k cells), the spatial index makes the feature query cheap, and
+the result is always fresh. Tile caching is an optimization if profiling
+shows it's needed.
+
+### 5.6 Module breakdown
+
+```
+enc_chart_loader        Library — parses S-57, produces feature stream.
+                        Uses GDAL/OGR (mature S-57 reader).
+
+enc_feature_index       Library — R-tree index over features, in map-frame coords.
+                        Projection happens at load.
+
+enc_costmap_layers      ROS package — five nav2 costmap layer plugins.
+                        Each plugin holds a reference to the shared feature index
+                        and queries it during update.
+
+enc_costmap_config      YAML schemas for:
+                          - operating area polygon
+                          - mission profile (resolution, extent)
+                          - vessel params
+                          - cost-mapping table (feature class + attrs → cost)
+                          - inflation per layer
+
+enc_costmap_diagnostics ROS topics for per-layer grids + a "provenance" overlay
+                        showing which feature dominated each cell.
+```
+
+Plugin model means nav2's existing `costmap_2d` node loads and runs everything
+— no separate node tree, no separate publisher logic.
+
+### 5.7 Coordinate handling
+
+- ENC in WGS84 (geographic).
+- Map frame: UTM, zone defaults to operating-area centroid's zone, configurable.
+- Projection at chart load time, into the spatial index. Re-projection per
+  query is wasteful and not needed.
+- Multi-zone operating areas (e.g., very large transit crossing UTM zone
+  boundaries): out of scope for v1, flagged for future. Portsmouth–Cape Cod
+  fits in Zone 19.
+- Local ENU origin: not needed — UTM with a sensible local origin offset
+  works, and TF chains from `map` are unaffected.
+
+### 5.8 Update model summary
+
+| Trigger                              | What recomputes                                     |
+|--------------------------------------|----------------------------------------------------|
+| Chart load                           | All five layers, full extent                        |
+| Tide change                          | Depth layer only, full extent (cached-clearance fast path deferred) |
+| Draft / safety-margin change         | Depth layer only                                    |
+| Vessel-class change                  | Soft Regulatory only                                |
+| Boat moves                           | Local window slides, vector-on-demand re-rasterization for local |
+| Operating area change                | Reload (treat as new mission)                       |
+
+## 6. v1 scope and deferrals
+
+### Ship in v1
+
+- The five layers above, with the feature classes listed.
+- DEPARE + SOUNDG (option b) depth handling.
+- UNSARE → 255.
+- Hard exclusions + soft preferences regulatory, config-driven attribute
+  mapping.
+- Single-area mission-scoped global, 0.5 m local sliding window.
+- Tide via scalar topic.
+- nav2 layer plugin integration.
+- Per-layer debug topics + provenance overlay.
+
+### Explicitly deferred (named, not ignored)
+
+- ZOC-based depth uncertainty.
+- Multi-zone operating area (β architecture).
+- TSS direction-of-travel awareness.
+- Vessel-class profiles beyond a single config.
+- Cached-clearance fast path for tide updates.
+- Multi-UTM-zone operating areas.
+- Spatially varying tide.
+- Time-varying restrictions (military activity periods, seasonal zones).
+
+## 7. Where confidence is low
+
+A few places where the answer is a best guess rather than a settled decision:
+
+- **Whether to treat `OBSTRN` as Hard Regulatory or Depth-conditional.** S-57
+  splits obstructions into surface-piercing and submerged via attributes
+  (`VALSOU`, `WATLEV`); the mapping above is the "right" interpretation, but
+  `OBSTRN` in real charts is messy and the attribute coverage is
+  inconsistent. Worth empirical inspection of actual charts before
+  committing.
+- **Whether MARCUL belongs in "Hard Regulatory" or a new "Physical Static
+  Obstacle" layer.** Argued for the former, but it's a physical thing, not
+  a regulation. Either is defensible; the cost is the same; the layer name
+  is cosmetic.
+- **The clearance-to-cost function shape.** Linear vs. smoothstep vs.
+  discrete bands — all defensible, none obviously right. Worth deciding by
+  what the operator's mental model is, not by mathematical elegance.
+- **Vector-on-demand for local vs. tile cache.** Committed to
+  vector-on-demand; tile cache could be better if the spatial index queries
+  turn out slower than expected. Worth profiling early.
+- **Whether SOUNDG inflation should be a fixed radius or read from `QUAPOS` /
+  `QUASOU` attributes when present.** Probably start with fixed and make it
+  data-driven later if `QUAPOS` is reliably populated in the charts that
+  actually matter.
+- **Whether SOUNDGs *deeper* than their containing DEPARE should be ignored
+  entirely (the recommendation here) or allowed to make a "1 m" band locally
+  read as 1.5 m.** Recommended ignore — the navigationally conservative
+  direction is shoaler-only.
+
+---
+
+**Authored-By**: `Claude Code Agent`
+**Model**: `Claude Opus 4.7 (1M context)`

--- a/docs/design/alternative_costmap_architecture.md
+++ b/docs/design/alternative_costmap_architecture.md
@@ -28,7 +28,7 @@ it, lightly edited for flow:
    late-breaking case (regional missions covering hundreds of km) and how it
    shaped the design.
 5. [Architecture](#5-architecture) — the actual pipeline, layer breakdown,
-   composition rule, modules, and update model.
+   composition rule, modules, update model, and persistence/lifecycle.
 6. [v1 scope and deferrals](#6-v1-scope-and-deferrals) — what should ship,
    and what is explicitly deferred.
 7. [Where confidence is low](#7-where-confidence-is-low) — places where the
@@ -532,7 +532,7 @@ interesting design choices live in the layer breakdown and the update strategy.
 
 ### 5.2 Layer breakdown
 
-Five logical layers, organized by **update trigger** rather than by feature
+Six logical layers, organized by **update trigger** rather than by feature
 type — that's the cut that actually matters operationally.
 
 | Layer             | Sources                                                  | Cost behavior        | Update trigger                       |
@@ -542,11 +542,13 @@ type — that's the cut that actually matters operationally.
 | **Soft regulatory** | `RESARE` (env / nature / fish), `FAIRWY`, `TSSLPT` / `TSEZNE`, `ACHARE` | Soft (config-driven) | Chart load + vessel-class change |
 | **Coverage**      | `UNSARE`, area outside any feature polygon, area outside loaded ENC cells | 255 unknown | Chart load |
 | **Depth**         | `DEPARE` (`DRVAL1`) + `SOUNDG` override + tide/draft-conditional `UWTROC` / `WRECKS` / `OBSTRN` | Continuous (depth → cost function) | Chart load + tide + draft |
+| **Overhead**      | `BRIDGE`, `CBLOHD`, `CONVYR` (with `VERCLR`)             | Tide-conditional lethal | Chart load + tide + air-draft     |
 
-The cut: 4 of the 5 layers are static after chart load. Only **Depth** needs
-continuous refresh. That asymmetry drives the implementation — static layers
-can be pre-rasterized and held; the depth layer is the only one with
-hot-path complexity.
+The cut: 4 of the 6 layers are static after chart load. **Depth** and
+**Overhead** both need continuous refresh — they share the tide trigger but
+have opposite sign on the clearance computation. Static layers can be
+pre-rasterized and held; the dynamic layers share the tide-driven recompute
+pass.
 
 Each layer is a `nav2_costmap_2d::Layer` plugin. Layered costmaps are
 exactly what nav2's plugin architecture is for; reusing it avoids reinventing
@@ -616,7 +618,56 @@ rates (minutes). At 0.5 m / 160 k cells (local window), trivially fast.
 cost. A tide update then just adds an offset to clearance and re-runs the
 cost function. Faster than re-rasterizing from vectors. v2 work.
 
-### 5.5 Static-layer rasterization
+### 5.5 The Overhead layer in detail
+
+Charted overhead structures (bridges, overhead cables, conveyors) become
+tide-conditional lethal cells, mirroring the Depth layer with **opposite
+sign** on the tide dependency.
+
+**Inputs:**
+
+- `BRIDGE` features (often line/area geometry along bridge centerlines) with
+  `VERCLR` (vertical clearance, typically referenced to MHW or HAT).
+- `CBLOHD` (overhead cable) features.
+- `CONVYR` (overhead conveyor) features.
+- Tide offset (scalar, same source as Depth).
+- Vessel air-draft + safety margin.
+
+**Per cell intersected by an overhead structure:**
+
+```
+charted_clearance   = feature.VERCLR
+                      (referenced to feature's chart datum, typically MHW or HAT)
+effective_clearance = charted_clearance + (reference_level - current_water_level)
+                      # high tide  → effective lower
+                      # low tide   → effective higher
+margin              = effective_clearance - vessel_air_draft - safety_margin
+```
+
+Cost mapping mirrors Depth's clearance-to-cost function:
+
+- `margin < 0`            → lethal (254)
+- `0 ≤ margin < warn`     → high cost, gradient
+- `margin ≥ safe`         → free (0)
+
+`warn` and `safe` thresholds may be smaller than the Depth equivalents
+because air-draft is typically more precisely known than effective bottom
+depth (no equivalent of sounding-density issues). Configurable.
+
+**Update model**: shares the tide-update recompute pass with Depth — at any
+tide change, both layers refresh. Vessel air-draft is configured per vessel
+and rarely changes.
+
+**Out of scope for v1:**
+
+- **Drawbridges / swing bridges / lift bridges** with `VERCCL` (closed
+  clearance) and `VERCOP` (open clearance). Open-state operation requires
+  bridge-tender coordination, not a costmap. v1 should treat the
+  conservative `VERCCL` value when both are present.
+- **Overhead power-line EMI hazards** at distance (compass / electronics
+  effects beyond the contact envelope). Charted clearance is the proxy.
+
+### 5.6 Static-layer rasterization
 
 Land, Hard Regulatory, Soft Regulatory, Coverage are computed once when the
 chart loads, into raster form, and held.
@@ -639,7 +690,7 @@ is tiny (~160 k cells), the spatial index makes the feature query cheap, and
 the result is always fresh. Tile caching is an optimization if profiling
 shows it's needed.
 
-### 5.6 Module breakdown
+### 5.7 Module breakdown
 
 ```
 enc_chart_loader        Library — parses S-57, produces feature stream.
@@ -647,8 +698,9 @@ enc_chart_loader        Library — parses S-57, produces feature stream.
 
 enc_feature_index       Library — R-tree index over features, in map-frame coords.
                         Projection happens at load.
+                        Persistent on-disk cache (see 5.10).
 
-enc_costmap_layers      ROS package — five nav2 costmap layer plugins.
+enc_costmap_layers      ROS package — six nav2 costmap layer plugins.
                         Each plugin holds a reference to the shared feature index
                         and queries it during update.
 
@@ -666,7 +718,7 @@ enc_costmap_diagnostics ROS topics for per-layer grids + a "provenance" overlay
 Plugin model means nav2's existing `costmap_2d` node loads and runs everything
 — no separate node tree, no separate publisher logic.
 
-### 5.7 Coordinate handling
+### 5.8 Coordinate handling
 
 - ENC in WGS84 (geographic).
 - Map frame: UTM, zone defaults to operating-area centroid's zone, configurable.
@@ -678,30 +730,79 @@ Plugin model means nav2's existing `costmap_2d` node loads and runs everything
 - Local ENU origin: not needed — UTM with a sensible local origin offset
   works, and TF chains from `map` are unaffected.
 
-### 5.8 Update model summary
+### 5.9 Update model summary
 
-| Trigger                              | What recomputes                                     |
-|--------------------------------------|----------------------------------------------------|
-| Chart load                           | All five layers, full extent                        |
-| Tide change                          | Depth layer only, full extent (cached-clearance fast path deferred) |
-| Draft / safety-margin change         | Depth layer only                                    |
-| Vessel-class change                  | Soft Regulatory only                                |
-| Boat moves                           | Local window slides, vector-on-demand re-rasterization for local |
-| Operating area change                | Reload (treat as new mission)                       |
+| Trigger                                  | What recomputes                                     |
+|------------------------------------------|----------------------------------------------------|
+| Chart load                               | All six layers, full extent                         |
+| Tide change                              | Depth + Overhead layers, full extent (cached-clearance fast path deferred) |
+| Draft change                             | Depth layer only                                    |
+| Air-draft change                         | Overhead layer only                                 |
+| Safety-margin change                     | Depth + Overhead layers (each uses its own margin)  |
+| Vessel-class change                      | Soft Regulatory only                                |
+| Boat moves                               | Local window slides, vector-on-demand re-rasterization for local |
+| Operating area change                    | Reload (treat as new mission)                       |
+| nav2 restart                             | All six layers reload from feature cache (see 5.10) |
+
+### 5.10 Persistence and lifecycle
+
+Cold-start time is dominated by GDAL S-57 parsing. To make startup and
+restart times reasonable, the parsed/projected/indexed feature store is
+persistent on disk.
+
+**Cache contents** (per ENC cell):
+
+- Parsed feature records (geometry + attributes).
+- Projection target (UTM zone) used at build time.
+- Source file mtime (for invalidation).
+
+**Cache invalidation**: cell mtime changes, projection params change, or
+schema/format version bump. On miss, re-parse and re-index that cell only.
+
+**Cold-start estimates** (with cache present):
+
+| Mission scope                              | Cold start time   |
+|--------------------------------------------|-------------------|
+| Harbor (1 cell, 5×5 km @ 2 m)              | ~2–4 s            |
+| Regional (20–50 cells, 200×100 km @ 16 m)  | ~8–20 s           |
+
+Without the cache, regional missions take 30–90 s due to S-57 parse cost
+alone — so the cache is in v1 scope, not deferred.
+
+**Restart downtime**: the design has the layers as `nav2_costmap_2d::Layer`
+plugins, so the feature store lives inside the `costmap_2d` process and
+dies when nav2 restarts. **Restart time = cold start time.** The cache
+makes that tolerable for regional missions (10–20 s, not 30–90 s).
+
+**Implication for vessel behavior during restart**: the boat needs a
+safe-state behavior (loiter / station-hold) that does not depend on the
+costmap, since the costmap is unavailable for ~10–20 s during regional
+mission restart. This is a vessel-side behavior contract, not a costmap
+concern, but it has to be explicit.
+
+**Alternative architecture (deferred)**: out-of-process ENC service that
+holds the parsed features and rasterized layers, with nav2 plugins
+querying it via service or shared memory. Survives nav2 restart entirely
+(restart downtime drops to ~2–5 s for nav2 lifecycle alone). Adds
+architecture complexity. Worth revisiting if field experience shows the
+~20 s regional restart is a problem.
 
 ## 6. v1 scope and deferrals
 
 ### Ship in v1
 
-- The five layers above, with the feature classes listed.
+- The six layers above, with the feature classes listed.
 - DEPARE + SOUNDG (option b) depth handling.
 - UNSARE → 255.
 - Hard exclusions + soft preferences regulatory, config-driven attribute
   mapping.
+- Overhead layer (`BRIDGE` / `CBLOHD` / `CONVYR`) with `VERCLR` and vessel
+  air-draft.
 - Single-area mission-scoped global, 0.5 m local sliding window.
 - Tide via scalar topic.
 - nav2 layer plugin integration.
 - Per-layer debug topics + provenance overlay.
+- Persistent on-disk cache for parsed feature index (per-cell, mtime-keyed).
 
 ### Explicitly deferred (named, not ignored)
 
@@ -713,6 +814,11 @@ Plugin model means nav2's existing `costmap_2d` node loads and runs everything
 - Multi-UTM-zone operating areas.
 - Spatially varying tide.
 - Time-varying restrictions (military activity periods, seasonal zones).
+- Drawbridge / swing-bridge / lift-bridge state and bridge-tender
+  coordination (use conservative `VERCCL` until then).
+- Overhead power-line EMI hazards beyond charted clearance.
+- Out-of-process ENC service architecture (plugins-only for v1; revisit if
+  ~20 s regional restart proves problematic).
 
 ## 7. Where confidence is low
 

--- a/docs/design/design_evolution.md
+++ b/docs/design/design_evolution.md
@@ -82,6 +82,45 @@ local at 0.5 m.
   function.** Stated to be smaller than the Depth equivalents but
   specific values not chosen.
 
+## 2026-04-25 — Round 3: prior-art summary added
+
+**Triggered by** the comparison-exercise framing being expanded to include
+an explicit prior-art reference point. Specifically the request to "dig up
+Sam Reed's thesis and prior work to use as an extra point of comparison"
+and to "acknowledge this is the spiritual successor to that work."
+
+### What was added
+
+- **New file**: [`prior_art_reed_2018.md`](prior_art_reed_2018.md), a
+  standalone neutral summary of Reed's 2018 MS thesis "Providing Nautical
+  Chart Awareness to Autonomous Surface Vehicles" (UNH ECE,
+  thesis-director Brian Calder, co-advisor Val Schmidt). Documents Reed's
+  MOOS-IvP-based architecture, Depth-Based A* mission planner with cost
+  function `G(n) = G(n-1) + DP + w·Cost_depth`, threat-level encoding,
+  ENC_DB / ENC_Contact / BHV_ENC_OA reactive stack, MOOSTides tide
+  handling, field test results, and Reed's stated limitations including
+  the "ENC scale and uncertainty" critique (breakwater installed 2006 but
+  omitted from ENC until 2018; "Breakers" label 88 m from actual hazard).
+
+### What this is *not*
+
+- Not a comparison to the alternative architecture in
+  `alternative_costmap_architecture.md` or to the existing
+  implementation in `s57_grids` / `s57_layer` / `marine_charts`. The
+  comparison exercise is a separate planned step.
+- Not a reproduction of the thesis. It captures the architectural
+  decisions and limitations sufficient for using as a reference point;
+  for full detail consult the thesis directly.
+
+### Acknowledgment
+
+The work in this repository is the spiritual successor to Reed's
+research. Many of the problems Reed identified (depth-area conflict
+resolution, qualitative-vs-quantitative depth, tide-corrected charted
+depth, vessel-size buffering, ENC scale and uncertainty) recur in any
+ENC-driven autonomy system, and Reed's solutions remain a useful
+reference point.
+
 ## How to add a new entry
 
 When the design doc gets meaningful changes (new section, changed

--- a/docs/design/design_evolution.md
+++ b/docs/design/design_evolution.md
@@ -121,6 +121,89 @@ depth, vessel-size buffering, ENC scale and uncertainty) recur in any
 ENC-driven autonomy system, and Reed's solutions remain a useful
 reference point.
 
+## 2026-04-25 — Round 4: Reed's code repositories located
+
+**Triggered by** the question "did you find a code repository for Reed's
+work? Can we find it and see if it contains more insight we should know
+about?"
+
+### What changed in `prior_art_reed_2018.md`
+
+- **New "Code availability" section** with three Reed-authored repositories
+  ([`sji367/MOOS_ENC`](https://github.com/sji367/MOOS_ENC),
+  [`sji367/moos-ivp-reed`](https://github.com/sji367/moos-ivp-reed),
+  [`sji367/ENC_Mission_Planner`](https://github.com/sji367/ENC_Mission_Planner))
+  and three Val-Schmidt reimplementation/tooling repos
+  ([`valschmidt/encgrid`](https://github.com/valschmidt/encgrid),
+  [`valschmidt/enc_dump`](https://github.com/valschmidt/enc_dump),
+  [`valschmidt/ReadingENCswithGeopandas`](https://github.com/valschmidt/ReadingENCswithGeopandas)).
+- **Implementation details** lifted from `encgrid`'s `notes_on_encgrid.txt`
+  (MULTIPOINT/SOUNDG bypass, `DEPCNT` linestring oddities, `OBSTRN`/`PONTON`/
+  `FLODOC`/`DYKCON` polygon-conversion path, internal cm-scaling, geotiff
+  upside-down quirk).
+- **Connections to this workspace** documented (verified against git
+  history, not inferred from filename overlap):
+  - `camp/src/camp/astar.h` and `astar.cpp` were imported from Reed on
+    2020-02-20 (commit `f464452 — "Add initial AStar support for Sam
+    Reid's work"`), about 14 months after the thesis. The rest of CAMP
+    is Roland Arsenault's independent work since 2016-10-25. Reed's
+    `ENC_Mission_Planner` was created 2017-05-16 — *after* CAMP — and
+    they share several filenames; the direction of any influence on
+    those files is not established here.
+  - `s57_tools` was first committed 2021-06-25 by Roland, ~2.5 years
+    after Reed's thesis. Its git history shows independent
+    authorship — no port commit from `encgrid` or `moos-ivp-reed`.
+    The conceptual overlap is real (both produce an ENC-derived 2D
+    depth surface), but the implementations are independent.
+
+### What was wrong / missing before
+
+- The Round-3 prior-art summary correctly cited the thesis but assumed
+  the code was unfindable. In fact Reed publishes under `sji367` and
+  his repos are public. Without the code, the prior-art doc had no way
+  to surface implementation choices that the thesis prose glosses
+  over — notably the SOUNDG/MULTIPOINT bypass, the per-feature-class
+  linestring rules, and the existence of an `AOF_Gauss` IvP utility
+  function not named in the thesis.
+- An earlier draft of this Round-4 entry asserted code lineages
+  ("CAMP ← Reed's `ENC_Mission_Planner`", "s57_tools ← encgrid ←
+  Reed's gridding") inferred from shared filenames. Git log
+  contradicted that: CAMP predates Reed's Qt planner by seven months,
+  and `s57_tools` has no import history from `encgrid`. The corrected
+  text states only what git history confirms (specific imported
+  files; independent first-commit dates) and explicitly does not
+  narrate direction of influence beyond what is documented in commits.
+  The user flagged the inference; existing memory feedback
+  ("No causal stories from similarity") was reinforced to add the
+  code-lineage-specific guidance "git log first."
+
+### Reed's repository activity
+
+The "last update" timestamps from GitHub search results (e.g.
+2025-07 on `MOOS_ENC` and `ENC_Mission_Planner`) are repository
+metadata changes, not code commits. Actual final code commits per
+repo:
+
+- `MOOS_ENC` — 2016-09-27 ("Updated the comments")
+- `ENC_Mission_Planner` — 2017-06-23 ("Cleaned up repo")
+- `moos-ivp-reed` — 2018-07-07 (uploading thesis-fieldwork log files
+  from "Pier Ops Day 2")
+
+Reed's code is essentially frozen since his thesis defense.
+
+### What's still open
+
+- The published `MOOS_ENC` code shows a `BHV_OA` / `BHV_OA_poly` split
+  (point vs polygon obstacles) that the thesis describes as a single
+  `BHV_ENC_OA`. Reading the actual code might surface other
+  thesis-vs-code drift worth knowing for the comparison phase. Not done
+  yet — flag for the comparison step if it becomes load-bearing.
+- The relationship between Reed's `moos-ivp-reed` (the moos-ivp-extend
+  scaffolding) and `MOOS_ENC` (the thesis-component code) isn't fully
+  mapped. They're both his work but the directory layouts differ; one
+  may be a refactor of the other or they may have served different
+  demos.
+
 ## How to add a new entry
 
 When the design doc gets meaningful changes (new section, changed

--- a/docs/design/design_evolution.md
+++ b/docs/design/design_evolution.md
@@ -1,0 +1,112 @@
+# Design Evolution Log
+
+Companion to [`alternative_costmap_architecture.md`](alternative_costmap_architecture.md).
+Records what was added or changed to the design document over time, what
+prompted each change, and what was wrong with the previous version. Use
+this when reading the design doc to understand which sections were original
+and which came from later questions / reviews — `git log` shows when, but
+not why.
+
+This is a living document. Append-only by convention; don't edit prior
+entries except for typo fixes.
+
+## 2026-04-25 — Initial draft (#23 / PR #24)
+
+First pass at the clean-room design. Walked through inputs and constraints,
+resolution and tiering, four prep questions (`SOUNDG`/`DEPARE`, `UNSARE`,
+regulatory features, operating area), the multi-leg mission scenario, and
+the resulting layered architecture with five layers, an explicit "out of
+scope" list, and a "where confidence is low" section.
+
+749 lines. Architecture had **5 layers** (Land, Hard Regulatory, Soft
+Regulatory, Coverage, Depth). nav2 plugin model. Single global + sliding
+local at 0.5 m.
+
+## 2026-04-25 — Round 2: caching, restart cost, overhead clearance
+
+**Triggered by follow-up questions** after the initial draft was committed:
+
+> "Can you estimate how long this could take to load up and be ready for
+> nav2 to plan? If a nav stack restart happens, what might be the down
+> time? Also, are you accounting for overhead clearance?"
+
+### What changed in `alternative_costmap_architecture.md`
+
+- **Added a sixth layer: Overhead.** Sources are `BRIDGE`, `CBLOHD`,
+  `CONVYR` (with `VERCLR`). Tide-conditional lethal cost, mirroring Depth
+  with **opposite sign** on the tide dependency (high tide → less air
+  clearance). New section 5.5 details the cost computation.
+- **Added section 5.10: Persistence and lifecycle.** Covers persistent
+  on-disk cache for parsed feature index, cold-start time estimates
+  (~2–4 s harbor / ~8–20 s regional with cache; ~30–90 s regional
+  without), restart downtime implications, and the deferred
+  out-of-process ENC service alternative.
+- **Updated the v1 scope** to include the Overhead layer + air-draft and
+  the parsed-feature cache.
+- **Updated the deferrals list** with drawbridge state, overhead-cable
+  EMI hazards, and the out-of-process ENC service architecture.
+- **Updated the update-model summary** (5.9, was 5.8) with rows for
+  Overhead, air-draft, and nav2 restart.
+- Renumbered subsections 5.6–5.9 (was 5.5–5.8) to make room for the new
+  Overhead section.
+
+### What was wrong in the initial draft
+
+- **Overhead clearance was a real gap.** The initial draft listed `BRIDGE`
+  in section 1's feature inventory but never created a layer for it.
+  `CBLOHD` (overhead cable) was not even mentioned — only `CBLSUB`
+  (submarine cable), which was correctly dismissed as "irrelevant for
+  surface navigation," but that dismissal silently dropped the overhead
+  case too. Vessels with significant air-draft (mast, antennas, sensors —
+  larger boats run 5–10 m+) would have hit a charted bridge with no cost
+  signal.
+- **Caching was implicit, not designed.** Cold-start time was never
+  analyzed. The design as written would force a 30–90 s cold start on
+  regional missions, which has direct implications for nav2 restart
+  behavior that should have been explicit. The doc now states the cache
+  contract (per-cell, mtime-keyed) and quantifies the cost trade.
+- **Vessel air-draft** was listed as a static vessel parameter in section
+  1's input list but was never used in any cost computation. With the
+  Overhead layer added, it now is.
+
+### What's still open after Round 2
+
+- **Whether to fold Overhead into Depth** for a single tide-driven
+  recompute, or keep them as separate layers. Kept separate in the
+  current design for cleaner debug provenance and operator understanding,
+  but the implementation could share a recompute pass internally.
+- **Whether the in-process plugin architecture needs revisiting** if
+  field experience shows ~10–20 s regional restart is too long. The
+  out-of-process ENC service alternative is sketched but deferred.
+- **`warn` and `safe` thresholds for the Overhead clearance-to-cost
+  function.** Stated to be smaller than the Depth equivalents but
+  specific values not chosen.
+
+## How to add a new entry
+
+When the design doc gets meaningful changes (new section, changed
+recommendation, dropped feature, scope shift), add an entry here:
+
+```markdown
+## YYYY-MM-DD — Short title
+
+**Triggered by**: <comment, review, field experience, related issue, etc.>
+
+### What changed
+
+- Specific section / decision changed.
+- ...
+
+### What was wrong / missing before
+
+- Honest accounting of the gap.
+- ...
+
+### What's still open
+
+- ...
+```
+
+Don't use this log for typo fixes, formatting, or clarifying rewrites that
+don't change the design. Use it when a future reader of the doc would
+benefit from knowing "this section was added in response to X."

--- a/docs/design/design_evolution.md
+++ b/docs/design/design_evolution.md
@@ -204,6 +204,33 @@ Reed's code is essentially frozen since his thesis defense.
   may be a refactor of the other or they may have served different
   demos.
 
+## 2026-04-25 — Round 5: chart-scale planner idea captured as starting point
+
+**Triggered by** the user sharing the seed of a third candidate design,
+distinct from both the clean-room costmap architecture and Reed's
+work, with the explicit caveat that they didn't have time to work it
+out and wanted it noted as a starting point for the next discussion.
+
+### What was added
+
+- **New file**: [`alternative_chart_scale_planner.md`](alternative_chart_scale_planner.md).
+  Captures the user's chart-collection planner idea: assemble a
+  per-voyage working set of ENC cells at varying scales (fine at
+  departure/arrival, coarse during transit), have the planner traverse
+  the collection by jumping to a coarser/finer chart as needed, and
+  consider whether cost can be supplied to nav2 as a plugin
+  (per-chart rasterization) or directly from vectors (skipping
+  rasterization). Lists open questions to pick up next time.
+
+### What this is not
+
+- Not a worked-out design — explicitly a starting-point note.
+- Not analyzed against the other two designs in this repo — the
+  comparison exercise comes later.
+- Not committed-to. Three designs are now on file (costmap
+  architecture, Reed's prior art, chart-scale planner), positioned
+  for the comparison step.
+
 ## How to add a new entry
 
 When the design doc gets meaningful changes (new section, changed

--- a/docs/design/prior_art_reed_2018.md
+++ b/docs/design/prior_art_reed_2018.md
@@ -1,0 +1,438 @@
+# Prior Art: Reed 2018 — "Providing Nautical Chart Awareness to Autonomous Surface Vehicles"
+
+A neutral, descriptive summary of Samuel Reed's 2018 MS thesis at UNH. The
+work in this repository (`s57_tools`) is the spiritual successor to Reed's
+research — it inherits the goal of giving autonomous surface vessels an
+ENC-derived sense of the marine environment, and many of the same problems
+(depth-area generalization, qualitative-vs-quantitative depth attributes,
+tide handling, cartographic scale) recur here in different form.
+
+This document captures Reed's approach for reference. It does not contrast
+that approach with the current implementation or with proposals in this
+repo — those comparisons live separately.
+
+## Citation
+
+> Reed, Samuel John. *Providing Nautical Chart Awareness to Autonomous
+> Surface Vehicles*. Master's Thesis, University of New Hampshire,
+> Department of Electrical and Computer Engineering, December 2018.
+> Thesis Director: Dr. Brian Calder (CCOM Associate Director).
+> Available at https://scholars.unh.edu/thesis/1256/
+
+Funded by NOAA Grant NA15NOS4000200. Co-advised by Val Schmidt (CCOM Research
+Project Engineer) along with Dr. Se Young Yoon and Dr. Kent Chamberlin (UNH ECE).
+
+## Goal
+
+Move ASV autonomy from ALFUS Level 3 (executes pre-planned missions, no
+environmental awareness) toward Level 4–5 (knowledge of local and planned
+path environment; hazard avoidance) using only Electronic Nautical Charts —
+no real-time bathymetric sensors required for the autonomy itself.
+
+The thesis argues ASVs need *both* an a-priori intelligent mission planner
+*and* a real-time reactive obstacle avoidance system, both informed by the
+chart, because:
+
+> Vehicles cannot unconditionally follow a pre-programmed list of waypoints
+> nor react to other vessels in real time without regard to these hazards.
+
+## Stack and architecture
+
+Built on **MOOS-IvP**, not ROS. Specifically:
+
+- **MOOS** (Mission Oriented Operating System): publish-subscribe middleware
+  with a centralized `MOOSDB` for inter-application communication.
+- **IvP Helm** (`pHelmIvP`): combines behavior modules into ship-driving
+  decisions. Each behavior produces an **IvP Function** — a polar utility
+  surface where azimuthal angle = heading, radial distance = speed, and
+  height = utility. The `IvP_Solver` finds the optimal (heading, speed) pair
+  by combining behaviors' surfaces.
+
+Reed adds four custom MOOS components alongside the pre-existing waypoint
+behavior, `pMarineViewer`, `uSimMarine`, and `pMarinePID`:
+
+| Component       | Role |
+|-----------------|------|
+| **`MOOSTides`** | Real-time tide prediction from NOAA harmonic constituents (uses Sam Cox's `pytides`). Single tide value per region. |
+| **`ENC_Contact`** | Pre-processes ENC into a queryable spatial database (`ENC_DB`); monitors vessel position; publishes per-heading utility values. |
+| **`ENC_DB`**    | Single shapefile of polygons with threat-level and buffered geometry, derived from ENC layers. |
+| **`ENC_WPT_Check`** | Validates user-provided waypoints against the chart; skips unreachable or unsafe waypoints mid-mission. |
+| **`BHV_ENC_OA`** | IvP behavior subscribing to `ENC_Contact`'s utility report; produces an avoidance heading utility surface combined with the waypoint behavior in the IvP Solver. |
+
+Below the autonomy stack, the planner (offline, separately) generates the
+mission's waypoints from the ENC.
+
+## Two distinct ENC representations
+
+Reed uses two derivations of the same ENC for two purposes:
+
+1. **Interpolated depth grid** — used by the offline mission planner.
+   Single-resolution rectilinear grid; resolution = 0.25 mm × ENC compilation
+   scale (so a 1:20,000 chart → 5 m grid). Built once per chart.
+2. **`ENC_DB`** — used by the real-time reactive OA. Polygons-only spatial
+   database, threat-level annotated, ASV-buffered. Built once per chart, queried
+   in a sliding 20·L × 20·L window around the vessel (where L is vessel length).
+
+The two representations are independent and serve different consumers.
+
+---
+
+## Part 1 — ENC Derived Mission Planner
+
+### Building the depth grid (Section 2.1.2)
+
+The planner's grid is built once per chart, offline:
+
+1. **Project**: ENC features WGS84 → UTM via GDAL.
+2. **Buffer obstacles**: every obstacle polygon expanded by
+   `B = (SM/2) · √(L² + W²)` where `SM` = safety margin (default 2),
+   `L` = vessel length, `W` = vessel width. After this, the ASV can be
+   treated as a point during planning.
+3. **Buffer point features**: chart points (rocks, buoys, beacons, wrecks)
+   buffered by 2 mm at chart scale (a chart point isn't a real point — it's
+   an icon with positional uncertainty).
+4. **Linear interpolation** of buffered polygon vertices to grid cells using GDAL.
+5. **Conflict resolution** via four raster masks:
+   - `M_COVR` — outer chart bounds.
+   - `DA_shoal` — depth-area minimum bounds.
+   - `DA_deep` — depth-area maximum bounds.
+   - `Points` raster — point obstacles (rocks, wrecks, buoys).
+   - `Polygons` raster — land, pontoons, shoreline construction, etc.
+6. **Algorithm 1: Water Level → Depth.** Converts qualitative `WATLEV` codes
+   to quantitative depths, scaled per ocean (Atlantic vs. Pacific):
+
+   ```
+   if Type == Land:                  depth = -(MHW + 2)
+   else if WATLEV == 2 (always dry): depth = -(MHW + 0.3048 · OceanScalar)
+   else if WATLEV == 3 (submerged):  depth =  0.3048 · OceanScalar
+   else if WATLEV == 4 (covers/uncovers): depth = -(MHW + 0.3048 · OceanScalar)
+   else if WATLEV == 5 (awash):      depth = -0.3048 · OceanScalar
+   ```
+
+   Atlantic uses scalar 1, Pacific uses scalar 2. MHW is the closest NOAA
+   tidal station's MHW value, assumed constant across the ENC. (Reed flags
+   this as inadequate for spatially varying tide and large-scale charts.)
+
+7. **Algorithm 2: Depth Resolution.** Per cell:
+   - If outside ENC bounds: cell = -10 (sentinel for unknown / no data).
+   - Else: clamp to depth-area band, then apply Points and Polygons rasters,
+     each only if shoaler than the current value. "Shoaler wins."
+
+The result is an interpolated 2D depth grid in metres below MLLW, with land
+encoded as negative depth.
+
+### Depth-Based A* (Section 2.1.3)
+
+Custom A* graph search on the depth grid. Cost function:
+
+```
+G(n) = G(n-1) + (DP + w · Cost_depth)
+
+Cost_depth = DP · (15 - AD)    if AD < 15 m
+           = 0                  if AD ≥ 15 m
+```
+
+Where:
+- `DP` = distance from cell `n` to its parent.
+- `AD` = average depth between the cells (integrating depth between the
+  endpoints, divided by their distance).
+- `w` = depth-cost tuning weight. `w = 0.15` was used for the C-Worker 4.
+
+The 15 m cutoff means depth penalties are zero in deep water — the planner
+behaves like nominal A* there, minimizing path length.
+
+**Branching factor 8** (as adopted from Yang's FAA*): each node connects to
+180 neighbors instead of the 8-Moore-neighbor classic A*. Heuristic is
+Euclidean distance to goal. Result: heading changes can be < 2°,
+producing shipboard-realistic paths.
+
+**Prohibited cells**: any cell where charted depth is less than `3 × draft`.
+Hardcoded multiplier on draft, not a configurable cost-to-clearance function.
+
+The cost function balances "go through the channel like a human mariner"
+(high `w` → conservative deep-water paths) against "take the shortest route"
+(low `w` → cuts corners through shallow but non-dangerous water). Reed
+demonstrates this with five weightings (0, 0.1, 0.15, 0.25, 0.5) on
+Portsmouth Harbor missions.
+
+### Mission planner integration
+
+The Depth-Based A* outputs waypoints. These feed the standard MOOS waypoint
+behavior, whose IvP Function defines preferred heading + speed. ENC_Contact
+adjusts the waypoint behavior's `lead` parameter dynamically (see below) so
+the vessel relaxes track-following near hazards.
+
+---
+
+## Part 2 — ENC Derived Obstacle Avoidance
+
+### `ENC_Contact` and `ENC_DB` (Section 2.2.4)
+
+`ENC_Contact` is a custom MOOS app that:
+
+1. Pre-processes ENC: filters out non-obstacle features, reorganizes the
+   ~20+ S-57 layers into a single shapefile of polygons.
+   ("Significantly more efficient... only needs to open, filter, and react
+   to a single layer instead of over 20.")
+2. Assigns each obstacle a **threat level** (see below).
+3. Buffers each obstacle by:
+
+   ```
+   B = (1 + 0.4 · TL) / 2 · √(L² + W²)
+   ```
+
+   So buffering scales from 1× the absolute minimum (TL = 0) to 3× (TL = 5).
+4. Optionally rasterizes a depth grid to polygonize areas shoaler than a
+   user-set minimum MLLW depth, treating those polygons as obstacles. Uses
+   only depth-relevant features (soundings, piles, shoreline construction,
+   depth areas, land, pontoons, docks) — distinct from the planner's grid.
+
+At runtime, `ENC_Contact`:
+- Identifies obstacles within a square search area of side `20·L` centered
+  on the ASV.
+- Runs an angular-sweep at 8° resolution over 360°.
+- Applies a low-pass filter (window 5) to smooth utility transitions at
+  polygon edges.
+- Publishes a heading-utility report at 5 Hz.
+
+### Threat level (Section 2.2.3)
+
+A new attribute Reed adds to every charted obstacle, range 0–5:
+
+| TL | Description       | pMarineViewer color |
+|----|-------------------|---------------------|
+| 0  | No threat         | (not shown)         |
+| 1  | Small threat      | Yellow-Green        |
+| 2  | Medium threat     | Gold                |
+| 3  | Large threat      | Orange              |
+| 4  | Great threat      | Red                 |
+| 5  | Land              | Black               |
+
+Determined by a flowchart (Figure 2.11):
+
+1. **Type-based** (Algorithm 3): Land/Dyke/Pontoon → 5; Shoreline construction
+   /Dock → 5; Buoy/Weed/Beacon → 3; TopMark/DayMark → 3.
+2. **Depth-based** (Algorithm 4) when `VALSOU` is given:
+
+   ```
+   Depth = MLLW_Depth + Current_Tide
+   if Depth ≤ 2·draft: TL = 4
+   else if Depth ≤ 3·draft: TL = 3
+   else if Depth ≤ 4·draft: TL = 2
+   else if Depth ≤ 5·draft: TL = 1
+   else: TL = 0
+   ```
+
+3. **Qualitative depth fallback**: use Algorithm 1 (WATLEV → depth) then
+   Algorithm 4.
+4. **Unresolvable**: post warning, set TL = 4 (worst-case treatment).
+
+### Distance-vs-utility curves (Section 2.2.5)
+
+For each polygon intersected by an angular-sweep ray, utility is computed:
+
+```
+Utility = min(2.5 · 2^D / TL², 100)
+```
+
+where `D` = distance to the obstacle in vessel lengths, `TL` = threat level.
+Higher utility = safer heading. Multiple polygons → keep minimum
+(most-conservative). Lower-threat-level obstacles only penalize headings
+when very close; higher-threat obstacles penalize from much further out
+(see Figure 2.15).
+
+### Reactive obstacle-avoidance behavior (`BHV_ENC_OA`)
+
+A new IvP behavior subscribing to `ENC_Contact`'s heading utility report:
+- Linearly interpolates between 8° increments to produce a smooth
+  per-heading IvP utility surface.
+- If the ASV is within 3 boat lengths of an obstacle, biases utility toward
+  the current heading: `U = PrevU · (1 - |H-Z|/360)` — penalizing radical
+  course changes near hazards.
+- Combined with the waypoint behavior in the IvP Solver to produce final
+  (heading, speed) commands.
+
+### Adjusting the waypoint-behavior lead parameter
+
+When obstacles are near, `ENC_Contact` increases the MOOS waypoint
+behavior's `lead` parameter, which controls how aggressively the vessel
+returns to the planned trackline:
+
+```
+SD = 3·L + 0.5·MTL                     (safety distance threshold)
+lead = 8                if (ΔD > 0 and D > SD)    (clear, default aggressive)
+     = MTL · 20         otherwise                  (near threat, relaxed)
+```
+
+Where `D` = distance to closest obstacle, `ΔD` = its change since last
+control iteration, `MTL` = max threat level in the search area. This makes
+the ASV deviate from the trackline when threats are nearby and resume
+aggressive trackline-following only after passing them.
+
+### Waypoint validity (`ENC_WPT_Check`, Section 2.2.6)
+
+Independent MOOS app that checks user-provided waypoints against the chart.
+Skips waypoints that are unreachable (e.g. inside an extended obstacle)
+once the ASV gets within a user-defined distance of the obstacle's boundary.
+This lets operators plan missions "with little regard to obstacles" and
+still complete safely.
+
+---
+
+## Tide handling (`MOOSTides`, Section 2.2.2)
+
+Tide prediction uses NOAA harmonic constituents from a user-specified tide
+station, evaluated at the current time using the `pytides` Python library.
+Reed publishes the predicted real-time tide and MHW offsets to MOOSDB; both
+the threat-level computation and the obstacle-buffer process consume them.
+
+Acknowledged limitations:
+- Single-region scalar — no spatial variation across an ENC.
+- Doesn't account for meteorological effects.
+- Doesn't account for tidal currents.
+
+Reed argues a more sophisticated tidal model "might not be worth the cost"
+unless tidal range is large or spatially variable.
+
+---
+
+## Field tests
+
+Two platforms used:
+- **Seafloor Systems EchoBoat** — small ASV, 1.68 m × 0.79 m × 0.28 m
+  (L × W × draft). Used for in-water field tests at UNH Pier.
+- **ASV Global C-Worker 4** — larger commercial ASV, 4.0 m × 1.58 m × 0.4 m.
+  Simulation only.
+
+### Mission-planner results (3.1)
+
+Three planned missions on real ENCs:
+1. **UNH Pier → Prescott Park** up the Piscataqua River. Path stayed in the
+   deep channel for almost the entire mission.
+2. **UNH Pier → Isle of Shoals**. Path mostly in the channel but
+   occasionally cut through shallower (but non-dangerous) water when that
+   was less costly than detouring to the deepest line.
+3. **Boston Harbor**. Path stayed near the channel; near the destination,
+   it cut a corner through shallower water. Drove ~2.5 m from a lateral
+   buoy — Reed flags this as a planner limitation: when point obstacles sit
+   inside relatively deep water, the depth-cost function doesn't penalize
+   the surrounding cells enough to push the path away. The reactive
+   component would mitigate this in execution.
+
+### Reactive OA results (3.2)
+
+**Synthetic ellipse (8 m × 5 m)**, simulation:
+
+| TL | EchoBoat min distance (sim) | C-Worker 4 min distance (sim) |
+|----|----------------------------|-------------------------------|
+| 1  | 1.8 m                      | 4.4 m                         |
+| 2  | 2.9 m                      | 5.8 m                         |
+| 3  | 3.4 m                      | 7.3 m                         |
+| 4  | 4.0 m                      | 7.9 m                         |
+| 5  | 4.2 m                      | 8.7 m                         |
+
+EchoBoat field test, same ellipse: TL=1 → 2.6 m, TL=3 → 4.8 m, TL=5 → 5.3 m.
+
+**Real charted obstacles**:
+- UNH Pier breakwater (entering cove) — EchoBoat avoided at 3.0 m.
+- UNH Pier breakwater (leaving cove) — EchoBoat squeezed between breakwater
+  and shallow water polygon, 1.1 m and 3.6 m closest approaches respectively.
+- UNH Pier itself, line-following — avoided at 3.4 m closest approach.
+
+### Combined planner + reactive (3.3)
+
+Boston Harbor mission with both Depth-Based A* and ENC_OA active. ENC_OA
+adjusted the planned mission near a buoy to give it more clearance.
+
+---
+
+## Limitations called out by Reed (Section 4)
+
+### 4.1.1 — Depth-Based A* mission planner
+
+Reed's stated limitations:
+- **Point obstacles inside deep water can be approached too closely.** When
+  a buoy/wreck sits in deep water, the surrounding cells aren't depth-penalized,
+  so the depth-cost function offers little disincentive to skim the buffered
+  obstacle. (Demonstrated in the Boston Harbor mission.)
+- **Single tide value across the chart** — inadequate for large or
+  spatially-variable tidal regions.
+- **Fixed branching factor / fixed depth threshold** — no adaptation to
+  vessel maneuvering or to mission scope.
+
+### 4.1.2 — Reactive obstacle avoidance
+
+- **Local minima.** The most consequential limitation. When the avoidance
+  utility function has multiple peaks (e.g. ASV between two obstacles), the
+  combined IvP function can oscillate between heading choices, leaving the
+  ASV stuck. Demonstrated in a UNH-Pier mission where the EchoBoat
+  oscillated and the mission had to be canceled (came no closer than 8.3 m,
+  but never made progress). Reed proposes invoking Depth-Based A* as a
+  fallback when stuck — left for future work.
+- **Behavior-only navigation may be insufficient** for missions requiring
+  field-of-view larger than the angular-sweep search area.
+
+### 4.2 — ENC scale and uncertainty
+
+This is the most generally applicable critique in the thesis. Several
+specific issues:
+
+- **Cartographic scale mismatch.** A typical Portsmouth Harbor chart at
+  1:20,000 is rendered at chart scale for human navigation, but
+  autonomous vessels need higher effective resolution to safely approach
+  the coast. Over-scaling the ENC for display does not uniformly
+  improve feature resolution — different feature types are optimized for
+  different display scales.
+- **Vector representation at the proper scale.** Path planning needs
+  features rendered at a navigation-appropriate scale (Figure 4.3).
+- **Buffering objects to original chart-scale extent.** A pier shown as
+  a thin line at chart scale is in reality a wider object (Figure 4.4 —
+  Little Harbor).
+- **Missing features.** Floating piers next to fixed piers may be omitted
+  entirely; the breakwater near UNH Pier was installed in 2006 but absent
+  from the ENC until summer 2018.
+- **Misplaced features.** Reed observed a "Breakers" hazard label located
+  88 m from the actual hazardous water, with the actual hazard visible in
+  satellite imagery (white water) and confirmed by underlying bathymetry.
+  This is "due to the cartographic depiction" — chart symbols are placed
+  for human readability, not autonomy precision.
+
+The takeaway: ENCs are designed for human chart-readers, not autonomous
+robots. They embed cartographic generalization and human-readability
+choices that introduce spatial errors at the scale autonomous vessels need.
+This is a lasting structural limitation, not something an algorithm can
+fully compensate for.
+
+---
+
+## Summary table
+
+| Concern             | Reed's approach                                                      |
+|--------------------|----------------------------------------------------------------------|
+| Stack              | MOOS-IvP                                                             |
+| Planning           | Custom Depth-Based A* on interpolated depth grid                     |
+| Reactive control   | IvP behaviors with utility surfaces, combined in IvP Solver          |
+| Chart representation | Two: depth-grid for planner, polygon `ENC_DB` for reactive         |
+| Resolution         | Single, scaled by ENC compilation scale (0.25 mm × scale)            |
+| Vessel handling    | Buffering at chart-time (planner) and threat-scaled buffering (`ENC_DB`); ASV treated as point |
+| Threat encoding    | 5-level discrete + special "Land" level                              |
+| Cost function      | Continuous: `G(n) = G(n-1) + DP + w·Cost_depth`                      |
+| Tide              | Real-time scalar offset from harmonic constituents (`pytides`)       |
+| Out-of-data       | -10 m sentinel                                                       |
+| WATLEV handling   | Algorithm 1: qualitative → quantitative with Atlantic/Pacific scalar |
+| DEPARE/SOUNDG conflict | Multi-raster (DA_shoal, DA_deep, Points, Polygons); shoaler wins |
+| Test platforms    | Seafloor Systems EchoBoat (field), ASV Global C-Worker 4 (sim)       |
+| Demonstrated      | Path planning, synthetic-ellipse OA, breakwater OA, pier OA          |
+| Failure mode      | Reactive: local minima at multi-obstacle scenarios. Planner: close approaches to point obstacles in deep water |
+
+## Lineage to this repository
+
+`s57_tools` (this repo) inherits Reed's research goal: ENC-derived
+environmental awareness for autonomous surface vessels operating in
+charted waters. It moves the concept from MOOS-IvP into ROS 2 and nav2,
+which changes a great deal architecturally — but the core problems
+Reed worked through (depth-area conflict resolution, qualitative-vs-
+quantitative depth, tide-corrected charted depth, vessel-size buffering,
+threat encoding, ENC scale and uncertainty) all recur, and Reed's
+solutions remain a useful reference point for evaluating any subsequent
+design.

--- a/docs/design/prior_art_reed_2018.md
+++ b/docs/design/prior_art_reed_2018.md
@@ -425,14 +425,110 @@ fully compensate for.
 | Demonstrated      | Path planning, synthetic-ellipse OA, breakwater OA, pier OA          |
 | Failure mode      | Reactive: local minima at multi-obstacle scenarios. Planner: close approaches to point obstacles in deep water |
 
-## Lineage to this repository
+## Code availability
 
-`s57_tools` (this repo) inherits Reed's research goal: ENC-derived
-environmental awareness for autonomous surface vessels operating in
-charted waters. It moves the concept from MOOS-IvP into ROS 2 and nav2,
-which changes a great deal architecturally — but the core problems
-Reed worked through (depth-area conflict resolution, qualitative-vs-
-quantitative depth, tide-corrected charted depth, vessel-size buffering,
-threat encoding, ENC scale and uncertainty) all recur, and Reed's
-solutions remain a useful reference point for evaluating any subsequent
-design.
+The thesis itself doesn't link to a code repository, but Reed's GitHub
+account [`sji367`](https://github.com/sji367) (registered as "Sam Reed,
+UNH CCOM") hosts the original source for the work, plus his advisor Val
+Schmidt published a C++ reimplementation of the gridding pipeline.
+Most of the code dates from 2016–2017 (the thesis is December 2018) —
+Reed evidently developed the system, then wrote the thesis describing it.
+
+### Reed's own repositories
+
+| Repo | Description | Last code push |
+|------|-------------|----------------|
+| [`sji367/MOOS_ENC`](https://github.com/sji367/MOOS_ENC) | The ENC obstacle-avoidance stack: `BHV_OA.cpp` (point-geometry OA behavior), `BHV_OA_poly.cpp` (polygon-geometry OA behavior — *split into two behaviors* in the published code, where the thesis describes one), `ENC_converter.py` (ENC→shapefile with threat-level annotation), `ENC_Search.py` (sliding-window search posting obstacles for OA), `ENC_Print.py` (pMarineViewer rendering), `ENC_WPT_check.py`, `AOF_Gauss.cpp` (custom IvP utility function with Gaussian falloff), plus example `alpha.moos`/`alpha.bhv` and a launcher. | 2016-09-27 |
+| [`sji367/moos-ivp-reed`](https://github.com/sji367/moos-ivp-reed) | MOOS-IvP `extend`-style scaffolding for "Sam Reed's Nautical Chart Awareness MOOS work" — `bin/`, `lib/`, `missions/`, `scripts/`, `src/` directory layout. | 2022-12-22 |
+| [`sji367/ENC_Mission_Planner`](https://github.com/sji367/ENC_Mission_Planner) | Qt5/QGraphics offline mission planner with chart loading, gridding (`griddingthread`), background raster rendering, and a vehicle-project model (`autonomousvehicleproject`). | 2017-06-23 |
+
+The published code is broadly consistent with the thesis description but
+contains evolutions: the single `BHV_ENC_OA` described in the thesis appears
+as two distinct behaviors in `MOOS_ENC` (`BHV_OA` for point obstacles,
+`BHV_OA_poly` for polygons), and `AOF_Gauss` (a Gaussian objective function)
+exists in code but isn't called out by name in the thesis.
+
+### Val Schmidt's reimplementation
+
+| Repo | Description | Last code push |
+|------|-------------|----------------|
+| [`valschmidt/encgrid`](https://github.com/valschmidt/encgrid) | Standalone C++ tool that converts an ENC into a raster depth GeoTIFF, "based on Sam Reed's Master's Thesis." Built on GDAL+BOOST. CLI: `encgrid -f ENC.000 -b buffer -r resolution`. Produces intermediate per-class shapefiles (polygon, point, depth_area, outline) then `gdal_rasterize`s and grids. Includes a candid `notes_on_encgrid.txt` design log. | 2020-01-24 |
+| [`valschmidt/enc_dump`](https://github.com/valschmidt/enc_dump) | Python tool to dump Layer/Feature/Attribute data from US ENCs (uses GDAL/OGR). Useful as a generic ENC inspection utility. | 2024-05 |
+| [`valschmidt/ReadingENCswithGeopandas`](https://github.com/valschmidt/ReadingENCswithGeopandas) | Tutorial / Colab notebook for reading ENCs with Geopandas. | 2022-01 |
+
+`encgrid` is Val Schmidt's standalone C++ port of Reed's planner-side
+gridding. The included `notes_on_encgrid.txt` is a candid maintainer's
+log — flags that geotiffs are written upside-down, that "MOOS_path was
+hardcoded to Sam's HD," that the A* implementation was bundled but should
+be split out, that internal scaling uses cm (multiply by 100), and walks
+through the per-feature-class handling rules in `layer2XYZ()`.
+
+The notes also surface several implementation choices not explicit in the
+thesis:
+
+- **MULTIPOINT features** (likely `SOUNDG` clusters) are extracted only as
+  X/Y/depth and not pushed into a shapefile — they bypass the buffering
+  pipeline.
+- **`DEPCNT` (depth contour)** handling differs from other linestrings:
+  segmented without buffering, with an unexplained UTM-origin subtraction
+  that the maintainer flags with "WHY?".
+- **`OBSTRN`, `PONTON`, `FLODOC`, `DYKCON`** linestrings are extracted,
+  buffered into polygons, depth-checked (with `WATLEV` fallback) and stored
+  in the polygon shapefile — *not* in the X/Y/depth point set.
+- **`POINT` features** (rocks, wrecks, obstructions, land) are added to
+  *both* the point shapefile and the X/Y/depth point set.
+
+These are exactly the kind of details a re-implementer would want to know
+and that the thesis description glosses over.
+
+## Connections to this workspace
+
+There are two separately documented points of contact between Reed's
+work and this workspace, plus a broader topical overlap that doesn't
+reduce to direct code re-use:
+
+### Reed's `astar.h` is incorporated into `camp`
+
+The file `camp/src/camp/astar.h` (and `astar.cpp`) carries the original
+header:
+
+```
+/*
+ * astar.h
+ *  Created on: Mar 21, 2017
+ *      Author: Sam Reed
+ */
+```
+
+This was added to CAMP on 2020-02-20 in commit
+`f464452 — "Add initial AStar support for Sam Reid's work"`
+(`git log src/camp/astar.h`), about 14 months after Reed's thesis was
+filed. The rest of CAMP is independently authored — CAMP's own first
+commit is 2016-10-25, predating Reed's `ENC_Mission_Planner` (created
+2017-05-16) by seven months. Shared filenames between the two Qt
+projects (`autonomousvehicleproject`, `backgroundraster`,
+`griddingthread`, etc.) exist; the direction of any influence on
+those files is not established here and shouldn't be inferred from
+filename overlap alone.
+
+### `s57_tools` and Reed's gridding share a problem statement
+
+`s57_tools` was first committed on 2021-06-25 by Roland Arsenault, two
+and a half years after Reed's thesis. The history (`git log --reverse
+--pretty=format:'%h %ad %s' --date=short`) shows it is original code
+authored against the ROS 2 / nav2 stack, not a port of `encgrid` or
+`moos-ivp-reed`. There is no commit message indicating an import from
+those repos, and no Reed authorship in the history.
+
+The conceptual overlap is genuine — both `s57_tools` and Reed's
+gridding work convert ENC vector features into a 2D depth surface
+suitable for navigation — but the implementations are independent.
+
+### Topical overlap regardless of code
+
+Many of the problems Reed worked through (depth-area conflict
+resolution, qualitative-vs-quantitative depth via WATLEV,
+tide-corrected charted depth, vessel-size buffering, threat encoding,
+ENC scale and uncertainty) recur in any ENC-driven autonomy system,
+including this one. The thesis remains a useful reference point even
+where the code lineage is independent.


### PR DESCRIPTION
## Summary

- Adds `docs/design/alternative_costmap_architecture.md` (749 lines).
- Records a clean-room design for ENC → nav2 costmap pipeline, deliberately
  produced **without consulting the existing implementation** in this repo.
- Captures the design *process* — inputs/constraints, four prep questions
  (SOUNDG/DEPARE, UNSARE, regulatory, operating area), the multi-leg mission
  scenario, and the resulting layered architecture — alongside the
  conclusions, with explicit "what's deferred" and "where confidence is low"
  sections.

The intent is to compare the two designs in a follow-up. This PR just lands
the alternative; the comparison is out of scope here.

## Test plan

- [x] Pre-commit hooks pass (trailing whitespace, end-of-file, line endings, large-files).
- [ ] Doc reviewed for technical accuracy against the conversation it captures.
- [ ] Follow-up: compare against existing implementation in `s57_grids` / `s57_layer` / `marine_charts`.

Closes #23.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
